### PR TITLE
schmatron rule for nested entries

### DIFF
--- a/Schemas/TEILex0/TEILex0.examples/examples.stripped.xml
+++ b/Schemas/TEILex0/TEILex0.examples/examples.stripped.xml
@@ -4,7 +4,7 @@
 To edit examples, please use TEILex0-examples.xml, 
 then transform using tei-stripper.xsl-->
 
-<?xml-model href="../out/TEILex0.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><TEI xmlns="http://www.tei-c.org/ns/Examples">
+<?xml-model href="../out/TEILex0.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="../TEILex0.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/Examples">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/Schemas/TEILex0/TEILex0.examples/examples.xml
+++ b/Schemas/TEILex0/TEILex0.examples/examples.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../out/TEILex0.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+
+<?xml-model href="../TEILex0.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>

--- a/Schemas/TEILex0/TEILex0.sch
+++ b/Schemas/TEILex0/TEILex0.sch
@@ -14,20 +14,19 @@
         </rule>
     </pattern>
 
-    <!-- 2019-02-24 (TT):  Allow only one gramGrp per entry-->
+    <!-- 2019-02-24 (TT):  Allow only one gramGrp per node-->
   <pattern>
-    <rule context="tei:entry/tei:gramGrp">
-        <report test="preceding-sibling::tei:gramGrp">There should be no more than one <name/> element as child of entry.</report>
+    <rule context="tei:*/tei:gramGrp">
+        <report test="preceding-sibling::tei:gramGrp">There should be no more than one <name/> element as child of <value-of select="name(..)"/>.</report>
     </rule>
     </pattern>
     
-    <!-- 2019-02-24 (TT):  Allow only one gramGrp per sense-->
+    <!-- 2020-06-18 (TT):  Allow only one gramGrp per node-->
+    
     <pattern>
-        <rule context="tei:sense/tei:gramGrp">
-            <report test="preceding-sibling::tei:gramGrp">There should be no more than one <name/> element as child of sense.</report>
+        <rule context="tei:entry/tei:entry">
+            <report test="not(@type)">Nested entries should be typed. TEI Lex-0 recommends <![CDATA[<entry type='relatedEntry'></entry>]]>.</report>
         </rule>
     </pattern>
-    
-
 
 </schema>

--- a/Schemas/TEILex0/out/TEILex0.rng
+++ b/Schemas/TEILex0/out/TEILex0.rng
@@ -5,7 +5,7 @@
          xmlns="http://relaxng.org/ns/structure/1.0"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2020-06-16T19:12:00Z. .
+Schema generated from ODD source 2020-06-18T06:09:39Z. .
 TEI Edition: Version 4.0.0. Last updated on
 	13th February 2020, revision ccd19b0ba
 TEI Edition Location: http://www.tei-c.org/Vault/P5/Version 4.0.0/


### PR DESCRIPTION
Added a Schematron rule for typeless nested entries. Our Schematron rules are currently an experimental feature.  I've associated the examples.xml file with them, we'll see how far we want to take them.