### PR TITLE
Add XSLT step to fix xml:base and xml:lang issues

### DIFF
--- a/Schemas/TEILex0/TEILex0.odd
+++ b/Schemas/TEILex0/TEILex0.odd
@@ -137,6 +137,7 @@
                     <change type="spec">Added <ref target="#TEI.model.languageProfile">model.languageProfile</ref> to better structure <gi>language</gi>.</change>
                     <change type="spec">Added <gi>ruby</gi> annotation support</change>
                     <change type="spec">Added <gi>measure</gi> (to be used, for instance, within <gi>extent</gi> in <gi>fileDesc</gi></change>
+                    <change type="xproc">Added a temporary step to fix xml:base and xml:lang issues in xincluded examples as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/256">#256</ref></change>
                 </listChange>
                 <listChange n="0.9.4">
                     <change when="2024-05-12" type="xproc">fix documentation build on macOS and Windows in oXygen XML Editor</change>

--- a/Schemas/TEILex0/stylesheets/xmlbase-fix.xsl
+++ b/Schemas/TEILex0/stylesheets/xmlbase-fix.xsl
@@ -1,31 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xmlns:teix="http://www.tei-c.org/ns/Examples" xpath-default-namespace="http://www.tei-c.org/ns/1.0" version="2.0" exclude-result-prefixes="tei teix">
-   
-   
- <!--   <xsl:template match="tei:ref[@type='cit'][not(@xml:id)]">
-      <xsl:copy>
-          <xsl:attribute name="xml:id">
-              <xsl:value-of select="generate-id()"/>
-          </xsl:attribute>
-          <xsl:apply-templates select="@*|node()" />
-      </xsl:copy>
-      
-   </xsl:template>-->
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    exclude-result-prefixes="#all"
+    version="2.0">
+    <xd:doc scope="stylesheet">
+        <xd:desc>
+            <xd:p><xd:b>Created on:</xd:b> Dec 9, 2025</xd:p>
+            <xd:p><xd:b>Author:</xd:b> Boris</xd:p>
+            <xd:p>Removes the <xd:b>xml:base</xd:b> attributes and empty <xd:b>xml:lang</xd:b> attributes from the results of the <xd:b>p:include</xd:b> step in the oXygen XML Editor.</xd:p>
+        </xd:desc>
+    </xd:doc>
     
-  <!--  temporary hack for base uri fix with xinclude and xproc-->
-    <xsl:template match="@xml:base"></xsl:template>
-    <xsl:template match="@xml:lang">
-        <xsl:if test="string-length(.)>0">
-            <xsl:copy/>
-        </xsl:if>
+    <xsl:template match="node() | @*">
+        <xsl:copy>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
     </xsl:template>
-   
-   <xsl:template match="node() | @*">
-       <xsl:copy>
-           <xsl:apply-templates select="node() | @*"/>
-       </xsl:copy>
-   </xsl:template>
     
+    
+    <xsl:template match="@xml:base" priority="2" />
+    <xsl:template match="@xml:lang[. = '']" priority="2" />
     
 </xsl:stylesheet>

--- a/Schemas/TEILex0/xproc/teilex0.xpl
+++ b/Schemas/TEILex0/xproc/teilex0.xpl
@@ -82,9 +82,28 @@
             <p:sink/>
         </p:otherwise>
     </p:choose>
-    <p:xslt name="odd2lite">
+    <p:xslt name="xmlbasefix">
         <p:input port="source">
             <p:pipe step="odd2odd" port="result"/>
+        </p:input>
+        <p:input port="stylesheet">
+            <p:document href="../stylesheets/xmlbase-fix.xsl"/>
+        </p:input>
+        <p:input port="parameters">
+            <p:pipe step='generateDocumentation' port='stylesheetParameters'/>
+        </p:input>
+    </p:xslt>
+    <p:choose>
+        <p:when test="$debug = 'true'">
+            <p:store href="results-new/xmlbase-fixed.xml" method="xml" indent="false"/>
+        </p:when>
+        <p:otherwise>
+            <p:sink/>
+        </p:otherwise>
+    </p:choose>
+    <p:xslt name="odd2lite">
+        <p:input port="source">
+            <p:pipe step="xmlbasefix" port="result"/>
         </p:input>
         <p:input port="stylesheet">
             <p:pipe step="stylesheet-odd2lite" port="result"/>


### PR DESCRIPTION
Fix DARIAH-ERIC/tei-lex-0#129 by introduceing a new XSLT step in the XProc pipeline to remove xml:base and empty xml:lang attributes from xincluded examples.