### PR TITLE
Deprecate 'government' gram type in favor of 'construction'

### DIFF
--- a/Schemas/TEILex0/TEILex0.odd
+++ b/Schemas/TEILex0/TEILex0.odd
@@ -138,6 +138,7 @@
                     <change type="spec">Added <gi>ruby</gi> annotation support</change>
                     <change type="spec">Added <gi>measure</gi> (to be used, for instance, within <gi>extent</gi> in <gi>fileDesc</gi></change>
                     <change type="xproc">Added a temporary step to fix xml:base and xml:lang issues in xincluded examples as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/256">#256</ref></change>
+                    <change type="spec">Deprecated <code>gram[@type="government"]</code> in favor of <code>gram[@type="government"]</code> as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/254">#254</ref></change>
                 </listChange>
                 <listChange n="0.9.4">
                     <change when="2024-05-12" type="xproc">fix documentation build on macOS and Windows in oXygen XML Editor</change>

--- a/Schemas/TEILex0/TEILex0.parts/02__entries.xml
+++ b/Schemas/TEILex0/TEILex0.parts/02__entries.xml
@@ -206,7 +206,7 @@
                <row>
                   <cell>-</cell>
                   <cell><code rend="language-xml">&lt;gram
-                        type="government">[+conj.]&lt;/gram></code></cell>
+                        type="construction">[+conj.]&lt;/gram></code></cell>
                </row>
                <row>
                   <cell>-</cell>
@@ -264,10 +264,10 @@
                rend="italic">de</hi>) and various types of grammatical co-occurrences, differently
             referred to in the literature as rection, government, dependency etc. The suggested value
             for this type of grammatical co-occurrence in TEI Lex-0 is <code rend="language-xml">&lt;gram
-               type="governement">&lt;/gram></code><egXML
+               type="construction">&lt;/gram></code><egXML
                xmlns="http://www.tei-c.org/ns/Examples">
                <gramGrp>
-                  <gram type="government">[+ conj.]</gram>
+                  <gram type="construction">[+ conj.]</gram>
                </gramGrp>
             </egXML>
          </p>

--- a/Schemas/TEILex0/TEILex0.parts/40__specification.xml
+++ b/Schemas/TEILex0/TEILex0.parts/40__specification.xml
@@ -796,13 +796,13 @@
                                 uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-case.html"
                             />
                         </valItem>
+                        <valItem ident="construction"/>
                         <valItem ident="degree"/>
                         <valItem ident="gender">
                             <equiv name="gen"
                                 uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-gen.html"
                             />
                         </valItem>
-                        <valItem ident="government"/>
                         <valItem ident="inflectionType">
                             <equiv name="iType"
                                 uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-iType.html"


### PR DESCRIPTION
Replaces the deprecated <gram type="government"> with <gram type="construction"> in documentation, examples, and specification files. Fix DARIAH-ERIC/tei-lex-0#128.