### PR TITLE
Make use of 'hypernymy' consisntent across the documentation

### DIFF
--- a/Schemas/TEILex0/TEILex0.parts/05__cross-references.xml
+++ b/Schemas/TEILex0/TEILex0.parts/05__cross-references.xml
@@ -134,14 +134,14 @@
                         </egXML>
         </div>
         <div>
-            <head>Hyperonymy</head>
+            <head>Hypernymy</head>
             <p>Relation between lexical heads X and Y characterised by the property that the
                 sentence This is a(n) Y entails, but is not entailed by the sentence This is a(n) X.
                 (Adapted from <ref target="#Cruse1986">Cruse 1986</ref>.) </p>
-            <p>Hyperonymy is the converse of hyponymy.</p>
+            <p>Hypernymy is the converse of hyponymy.</p>
             <p> Example: dog/animal (animal is a hypernym of dog)</p>
-            <p>In TEI Lex-0, hyperonyms are encoded inside <code>&lt;xr
-                    type=&quot;hyperonymy&quot;&gt;&lt;/xr&gt;</code>.</p>
+            <p>In TEI Lex-0, hypernyms are encoded inside <code>&lt;xr
+                    type=&quot;hypernymy&quot;&gt;&lt;/xr&gt;</code>.</p>
             <egXML xmlns="http://www.tei-c.org/ns/Examples">
                <xi:include href="../TEILex0.examples/examples.stripped.xml" corresp="../TEILex0.examples/examples.xml" xpointer="XY.dog"/>
              </egXML>

--- a/Schemas/TEILex0/TEILex0.parts/06__usage.xml
+++ b/Schemas/TEILex0/TEILex0.parts/06__usage.xml
@@ -269,7 +269,7 @@
             </item>
             <item>Do not use <code>&lt;usg type=&quot;hyper&quot;&gt;&lt;/usg&gt;</code> or
                     <code>&lt;usg type=&quot;syn&quot;/&gt;</code> to mark lexical relations such as
-                hyperonymy or synonymy. The recommended way to encode lexical relations in TEI Lex-0
+                hypernymy or synonymy. The recommended way to encode lexical relations in TEI Lex-0
                 the reference mechanism provided by <gi>xr</gi>. See the secion on the <ref
                     target="#cross-references">typology of cross-references.</ref>.</item>
             <item>Do not use <code>&lt;usg type=&quot;colloc&quot;&gt;&lt;/usg&gt;</code> or for

--- a/Schemas/TEILex0/TEILex0.parts/40__specification.xml
+++ b/Schemas/TEILex0/TEILex0.parts/40__specification.xml
@@ -195,7 +195,7 @@
                                 property that the sentence ‘This is a(n) Y’ entails, but is not
                                 entailed by the sentence ‘This is a(n) X’. (Adapted from Cruse (1986).) </desc>
                             <remarks>
-                                <p>Hyperonymy is the converse of hyponymy.</p>
+                                <p>Hypernymy is the converse of hyponymy.</p>
                                 <p> Example: dog/animal (animal is a hypernym of dog)</p>
                             </remarks>
                         </valItem>


### PR DESCRIPTION
Replaces uses of 'hyperonymy' and 'hyperonym' with 'hypernymy' and 'hypernym' in the specification.  Fix DARIAH-ERIC/tei-lex-0#122