### PR TITLE
Update gram type from 'rection' to 'government'

### DIFF
--- a/Schemas/TEILex0/TEILex0.parts/04__senses.xml
+++ b/Schemas/TEILex0/TEILex0.parts/04__senses.xml
@@ -159,12 +159,12 @@
             <egXML xmlns="http://www.tei-c.org/ns/Examples">
                 <sense n="1" xml:id="LD.peto.1">
                     <gramGrp>
-                        <gram type="rection">aliquid ab aliquo</gram>
+                        <gram type="government">aliquid ab aliquo</gram>
                     </gramGrp>
                 </sense>
                 <sense n="1" xml:id="LD.peto.2">
                     <gramGrp>
-                        <gram type="rection">Romam</gram>
+                        <gram type="government">Romam</gram>
                     </gramGrp>
                 </sense>
             </egXML>


### PR DESCRIPTION
Replaces the 'gram' element's type attribute value from 'rection' to 'government' in two example senses. Fix DARIAH-ERIC/tei-lex-0#118