### PR TITLE
Update usage example in documentation

### DIFF
--- a/Schemas/TEILex0/TEILex0.odd
+++ b/Schemas/TEILex0/TEILex0.odd
@@ -139,6 +139,7 @@
                     <change type="spec">Added <gi>measure</gi> (to be used, for instance, within <gi>extent</gi> in <gi>fileDesc</gi></change>
                     <change type="xproc">Added a temporary step to fix xml:base and xml:lang issues in xincluded examples as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/256">#256</ref></change>
                     <change type="spec">Deprecated <code>gram[@type="government"]</code> in favor of <code>gram[@type="government"]</code> as per <ref target="https://github.com/DARIAH-ERIC/lexicalresources/issues/254">#254</ref></change>
+                    <change type="docs">Minor corrections in the documentation</change>
                 </listChange>
                 <listChange n="0.9.4">
                     <change when="2024-05-12" type="xproc">fix documentation build on macOS and Windows in oXygen XML Editor</change>

--- a/Schemas/TEILex0/TEILex0.parts/06__usage.xml
+++ b/Schemas/TEILex0/TEILex0.parts/06__usage.xml
@@ -47,7 +47,7 @@
                         lexical unit on a scale from old to new. Syn: diachronic marking; diachronic
                         information; time label.</gloss>
                     <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="unwrapped"><usg
-                            type="time"/></egXML>
+                            type="temporal"/></egXML>
                 </item>
                 <item>
                     <term>geographic label</term>: <gloss>marker which identifies the place or


### PR DESCRIPTION
Changed the value of @type in usg example from 'time' to 'temporal' in accordance with the recommendation. Fix DARIAH-ERIC/tei-lex-0#116