### PR TITLE
Fix XSD UPA violations

### DIFF
--- a/Schemas/TEILex0/TEILex0.examples/etym.xml
+++ b/Schemas/TEILex0/TEILex0.examples/etym.xml
@@ -4,22 +4,26 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Title</title>
+            <title>TEI Lex-0: Examples of Etymology</title>
          </titleStmt>
          <publicationStmt>
-            <p>Publication Information</p>
+            <authority> DARIAH WG "Lexical Resources"</authority>
          </publicationStmt>
-         <sourceDesc>
-            <p>Information about the source</p>
-         </sourceDesc>
       </fileDesc>
+      <profileDesc>
+         <langUsage>
+            <language role="objectLanguage" ident="de"/>
+            <language role="objectLanguage" ident="en"/>
+         </langUsage></profileDesc>
    </teiHeader>
    <text>
       <body>
-         <!--organize entries alphabetically-->
+         <!-- This file still doesn't validate! It's here to help us
+         do the necessary customizations so that we can fully support
+         etymologies. Still TODO. -->
          <entry xml:id="Eingang" xml:lang="de">
             <form type="lemma"><orth>Eingang</orth></form>
-            <gramGrp><gen>m.</gen></gramGrp>
+            <gramGrp><gram type="pos">m.</gram></gramGrp>
             <etym>
                <cit type="etymon">
                   <lang expand="Mittel Hoch Deutsch">mhd.</lang>
@@ -44,8 +48,8 @@
                </cit>
                <seg type="desc">Aus dem ‘Hineingehen’ als Handlung ist die ‘Stelle, an der man ins
                   Haus, in den Saal geht’ geworden, neuerdings auch die ‘Gesamtheit der
-                  eingegangenen Geschäftssachen, Mannschaften’ usw. Vgl. <xr type="crossReference">
-                     <ref>Zugang</ref>
+                  eingegangenen Geschäftssachen, Mannschaften’ usw. Vgl. <xr type="related">
+                     <ref type="entry">Zugang</ref>
                   </xr>. <bibl>(Kluge, 1975) p. 159</bibl></seg>
             </etym>
             <entry xml:id="Eingang2" xml:lang="de">
@@ -64,8 +68,8 @@
                      <seg type="desc">Aus dem ‘Hineingehen’ als Handlung ist die ‘Stelle, an der man
                         ins Haus, in den Saal geht’ geworden, neuerdings auch die ‘Gesamtheit der
                         eingegangenen Geschäftssachen, Mannschaften’ usw. Vgl. <xr
-                           type="crossReference">
-                           <ref>Zugang</ref>
+                           type="related">
+                           <ref type="entry">Zugang</ref>
                         </xr>. <bibl>(Kluge, 1975) p. 159</bibl></seg>
                   </etym>
                </etym>
@@ -156,18 +160,18 @@
             </entry>
          </entry>
          <!--suffixal derivation-->
-         <entry xml:lang="pt">
+         <entry xml:lang="pt" xml:id="PD.humanal">
             <form type="lemma">
                <orth xml:lang="pt">húmanal</orth>
                <pron xml:lang="pt" notation="ipa">umɐnáł</pron>
             </form>
             <gramGrp>
-               <pos>adj.</pos>
-               <gen>m.</gen>
+               <gram type="pos">adj.</gram>
+               <gram type="gender">m.</gram>
                <lbl>e</lbl>
-               <gen>f.</gen>
+               <gram type="gender">f.</gram>
             </gramGrp>
-            <etym type="suffixalDerivation">
+            <etym type="derivation">
                <pc>(</pc>
                <seg type="desc">De</seg>
                <cit type="etymon">
@@ -178,7 +182,7 @@
                <pc>+</pc>
                <cit type="etymon">
                   <gramGrp>
-                     <gram>suf.</gram>
+                     <gram type="pos">suf.</gram>
                   </gramGrp>
                   <form>
                      <orth extent="suff" xml:lang="pt">-al</orth>
@@ -206,11 +210,11 @@
                   </cit>
                   <pc>;</pc>
                </etym>
-               <seg type="desc" part="F">the spelling <xr type="crossReference">
-                     <ref xml:lang="la">allers</ref>
-                  </xr> would then be <xr type="crossReference">
+               <seg type="desc" part="F">the spelling <xr type="related">
+                     <ref xml:lang="la" type="entry">allers</ref>
+                  </xr> would then be <xr type="related">
                      <lbl>analogical to</lbl>
-                     <ref xml:lang="la">sollers</ref>
+                     <ref xml:lang="la" type="entry">sollers</ref>
                   </xr><pc>.</pc></seg>
             </etym>
 
@@ -223,8 +227,8 @@
                      <!-- Lat. sollers < *soti-arti- to sollus 'entire'; al(l)ers < *all-arti- to O. alio- 'entire'. -->
                      <seg type="desc" part="I">According to</seg>
                      <bibl>Untermann 2000</bibl>, <lang>Latin</lang>
-                     <xr type="crossReference">
-                        <ref xml:lang="la">*all-</ref>
+                     <xr type="related">
+                        <ref xml:lang="la" type="entry">*all-</ref>
                      </xr>
                      <seg type="desc" part="M">was probably borrowed from</seg>
                      <cit type="etymon" xml:lang="und-x-sabe1249">
@@ -248,11 +252,11 @@
                         </cit>
                         <pc>;</pc>
                      </etym>
-                     <seg type="desc" part="F">the spelling <xr type="crossReference">
-                           <ref xml:lang="la">allers</ref>
-                        </xr> would then be <xr type="crossReference">
+                     <seg type="desc" part="F">the spelling <xr type="related">
+                           <ref xml:lang="la" type="entry">allers</ref>
+                        </xr> would then be <xr type="related">
                            <lbl>analogical to</lbl>
-                           <ref xml:lang="la">sollers</ref>
+                           <ref xml:lang="la" type="entry">sollers</ref>
                         </xr><pc>.</pc></seg></etym>
                </etym>
             </entry>

--- a/Schemas/TEILex0/TEILex0.examples/examples.stripped.xml
+++ b/Schemas/TEILex0/TEILex0.examples/examples.stripped.xml
@@ -17,7 +17,7 @@ then transform using tei-stripper.xsl-->
             <principal/>
          </editionStmt>
          <publicationStmt>
-            <distributor>DARIAH WG Lexical Resources</distributor>
+            <publisher>DARIAH WG Lexical Resources</publisher>
             <availability>
                <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
             </availability>
@@ -36,7 +36,7 @@ then transform using tei-stripper.xsl-->
    </teiHeader>
    <text>
       <body>
-         <!--organize entries alphabetically-->
+        <!--organize entries alphabetically-->
          <entry type="mainEntry" xml:lang="cz" xml:id="en000008">
             <form type="lemma" xml:id="en000008.hw1">
                <orth>abeceda</orth>
@@ -524,7 +524,7 @@ then transform using tei-stripper.xsl-->
                      <orth>
                         <ref type="entry" scope="currentEntry">
                            <seg>corpo</seg>
-                           <lbl rend="sup">+</lbl>
+                           <metamark rend="sup">+</metamark>
                         </ref>
                         <seg>de bombeiros</seg>
                      </orth>
@@ -631,7 +631,7 @@ then transform using tei-stripper.xsl-->
                   <form type="collocation">
                      <orth>
                         <ref type="form" scope="currentEntry" value="descalçar">
-                           <lbl>+</lbl>
+                           <metamark>+</metamark>
                         </ref>
                         <seg>as botas</seg>
                      </orth>
@@ -665,7 +665,7 @@ then transform using tei-stripper.xsl-->
                   <form type="collocation">
                      <orth>
                         <ref type="form" scope="currentEntry" value="descalçar">
-                           <lbl>+</lbl>
+                           <metamark>+</metamark>
                         </ref>
                         <seg>os sapatos</seg>
                      </orth>

--- a/Schemas/TEILex0/TEILex0.examples/examples.xml
+++ b/Schemas/TEILex0/TEILex0.examples/examples.xml
@@ -15,7 +15,7 @@
             <principal></principal>
          </editionStmt>
          <publicationStmt>
-            <distributor>DARIAH WG Lexical Resources</distributor>
+            <publisher>DARIAH WG Lexical Resources</publisher>
             <availability>
                <licence target="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</licence>
             </availability>
@@ -32,7 +32,7 @@
    </teiHeader>
    <text>
       <body>
-         <!--organize entries alphabetically-->
+        <!--organize entries alphabetically-->
          <entry type="mainEntry" xml:lang="cz" xml:id="en000008">
             <form type="lemma" xml:id="en000008.hw1">
                <orth>abeceda</orth>
@@ -511,8 +511,8 @@
                <entry xml:id="DLPC.corpo_de_bombeiros" xml:lang="pt" type="relatedEntry">
                   <form type="lemma">
                      <orth>
-                        <ref type="entry" scope="currentEntry"><seg>corpo</seg><lbl rend="sup"
-                              >+</lbl></ref>
+                        <ref type="entry" scope="currentEntry"><seg>corpo</seg><metamark rend="sup"
+                              >+</metamark></ref>
                         <seg>de bombeiros</seg>
                      </orth>
                   </form>
@@ -611,7 +611,7 @@
                <form type="collocations">
                   <form type="collocation">
                      <orth>
-                        <ref type="form" scope="currentEntry" value="descalçar"><lbl>+</lbl></ref>
+                        <ref type="form" scope="currentEntry" value="descalçar"><metamark>+</metamark></ref>
                         <seg>as botas</seg>
                      </orth>
                      <gramGrp>
@@ -643,7 +643,7 @@
                <form type="collocations">
                   <form type="collocation">
                      <orth>
-                        <ref type="form" scope="currentEntry" value="descalçar"><lbl>+</lbl></ref>
+                        <ref type="form" scope="currentEntry" value="descalçar"><metamark>+</metamark></ref>
                         <seg>os sapatos</seg>
                      </orth>
                      <gramGrp>

--- a/Schemas/TEILex0/TEILex0.parts/40__specification.xml
+++ b/Schemas/TEILex0/TEILex0.parts/40__specification.xml
@@ -5,11 +5,9 @@
     xml:id="specification">
     <head>Specification</head>
     <schemaSpec ident="TEILex0" docLang="en" xml:lang="en">
-        
         <!-- ========================================================= -->
         <!-- SECTION: MODULES                                          -->
         <!-- ========================================================= -->
-        
         <!--2018-09-11 (TT): this is superflous because we're removing all
         elements from analysis -->
         <moduleRef key="analysis" except="cl interp interpGrp m phr s span spanGrp w"/>
@@ -29,7 +27,7 @@
         <moduleRef key="core"
             include="abbr analytic author bibl biblScope biblStruct cit citedRange date desc
             editor email expan gloss graphic head hi imprint item list listBibl measure
-            monogr name num p pubPlace publisher quote rb ref resp respStmt rt ruby term
+            monogr name note num p pubPlace publisher quote rb ref resp respStmt rt ruby term
             title"/>
         <!-- 2020-11-27 (TT): for language profiles -->
         <moduleRef key="corpus" include="channel domain interaction purpose settingDesc"/>
@@ -70,11 +68,9 @@
         <moduleRef key="textstructure" include="back body div front TEI text"/>
         <!-- LR (2019-11-14) Adding the transc module just to have metamark - as discussed with TT at the DH master class in FU Berlin-->
         <moduleRef key="transcr" include="metamark"/>
-        
         <!-- ========================================================= -->
         <!-- SECTION: ELEMENTS                                         -->
         <!-- ========================================================= -->
-        
         <!--2021-09-21 (TT): add @role to authority so that we can specify
         what kind of authority we're talking about; for instance 
         <authority role="rightsHolder"></authority>-->
@@ -121,7 +117,8 @@
             <content>
                 <alternate minOccurs="1" maxOccurs="unbounded">
                     <classRef key="model.quoteLike"/>
-                    <classRef key="model.egLike"/>
+                    <!--we don't need `eg` or `egXML` in cit-->
+                    <!--<classRef key="model.egLike"/>--> 	
                     <classRef key="model.biblLike"/>
                     <classRef key="model.ptrLike"/>
                     <classRef key="model.global"/>
@@ -156,7 +153,7 @@
         <!--2020-06-30 (TT): def is only allowed within a sense!-->
         <!--TODO: at the moment, it's still allowed in etym, but it shouldn't be
         because if there is no sense, we have to use gloss. fix later-->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="def" mode="change">
             <classes mode="change">
                 <memberOf key="model.sensePart" mode="add"/>
@@ -164,7 +161,7 @@
                 <memberOf key="model.entryPart" mode="delete"/>
             </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexSpecialPara"/>
             </content>
         </elementSpec>
         <elementSpec ident="desc" mode="change">
@@ -173,14 +170,17 @@
             </classes>
         </elementSpec>
         <elementSpec ident="dictScrap" mode="change">
+            <classes>
+                <memberOf key="sensePart" mode="add"/>
+            </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
                     <textNode/>
                     <classRef key="model.gLike"/>
                     <classRef key="model.entryPart"/>
                     <classRef key="model.morphLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
+                    <classRef key="model.lexPhrase"/>
+                    <classRef key="model.lexInter"/>
                     <classRef key="model.global"/>
                 </alternate>
             </content>
@@ -234,8 +234,8 @@
                     <textNode/>
                     <classRef key="model.gLike"/>
                     <classRef key="model.global"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.lexicalPhrase"/>
+                    <classRef key="model.lexInter"/>
+                    <classRef key="model.lexPhrase"/>
                     <classRef key="model.descLike"/>
                     <elementRef key="def"/>
                     <elementRef key="etym"/>
@@ -305,26 +305,31 @@
                 </sequence>
             </content>
         </elementSpec>
-        <!-- adding form to model.sensePart -->
         <elementSpec ident="form" mode="change">
             <classes mode="change">
                 <memberOf key="model.sensePart" mode="add"/>
+                <memberOf key="model.lexFormPart" mode="add"/>
             </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
                     <textNode/>
                     <classRef key="model.gLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.formPart"/>
+                    <classRef key="model.lexPhrase"/>
+                    <classRef key="model.lexInter"/>
+                    <classRef key="model.lexFormPart"/>
                     <classRef key="model.global"/>
                 </alternate>
             </content>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="gloss" mode="change">
+            <classes>
+                <memberOf key="model.lexEmphLike" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="gram" mode="change">
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
             <attList>
                 <attDef ident="type" mode="replace" usage="req">
@@ -379,24 +384,28 @@
         </elementSpec>
         <!-- adding gramGrp to model.sensePart -->
         <elementSpec ident="gramGrp" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-            </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
                     <textNode/>
                     <classRef key="model.gLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.gramPart"/>
+                    <classRef key="model.lexPhrase"/>
+                    <classRef key="model.lexInter"/>
+                    <!--<classRef key="model.gramPart"/>-->
+                    <elementRef key="gramGrp"/>
+                    <elementRef key="usg"/>
+                    <classRef key="model.morphLike"/>
+                    <!--gram-->
                     <classRef key="model.global"/>
                 </alternate>
             </content>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="hyph" mode="change">
+            <classes>
+                <memberOf key="model.lexFormPart" mode="add"/>
+            </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
         </elementSpec>
         <elementSpec ident="ident" mode="change">
@@ -411,17 +420,17 @@
         </elementSpec>
         <!-- adding lang to model.entryPart (to make it member of <cit>, if you ask) -->
         <!-- 2019-10-22 (LR) created ambiguous models... mended -->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="lang" mode="change">
             <!--<classes mode="change">
                             <memberOf key="model.entryPart" mode="add"/>
                         </classes>-->
             <classes mode="change">
-                <!--because we don't use model.nameLike in model.lexicalPhrase-->
-                <memberOf key="model.lexicalPhrase" mode="add"/>
+                <!--because we don't use model.nameLike in model.lexPhrase-->
+                <memberOf key="model.lexPhrase" mode="add"/>
             </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
             <exemplum>
                 <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="d1e5322">
@@ -515,7 +524,8 @@
                     language.</p>
                 <egXML xmlns="http://www.tei-c.org/ns/Examples">
                     <langUsage>
-                        <language ident="chu" role="sourceLanguage"><name>Old Church Slavic</name></language>
+                        <language ident="chu" role="sourceLanguage"><name>Old Church
+                            Slavic</name></language>
                         <language ident="la" role="targetLanguage"><name>Latin</name></language>
                         <language ident="grc" role="targetLanguage"><name>(Premodern)
                             Greek</name></language>
@@ -565,7 +575,8 @@
             <exemplum>
                 <egXML xmlns="http://www.tei-c.org/ns/Examples">
                     <langUsage>
-                        <language ident="chu" role="sourceLanguage"><name>Old Church Slavic</name></language>
+                        <language ident="chu" role="sourceLanguage"><name>Old Church
+                            Slavic</name></language>
                         <language ident="la" role="targetLanguage"><name>Latin</name></language>
                         <language ident="grc" role="targetLanguage"><name>(Premodern)
                             Greek</name></language>
@@ -576,14 +587,32 @@
         <!-- adding lbl to model.sensePart -->
         <elementSpec ident="lbl" mode="change">
             <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
                 <!--2019-02-19 (TT): changed from 'delete' (which was in error) to 'add' in model.entryPart.top";
                                 this is temporary because of issue with oxygen and tei-c servers; is already part of TEI-->
                 <memberOf key="model.entryPart.top" mode="add"/>
-                <memberOf key="model.emphLike" mode="add"/>
             </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
+            </content>
+        </elementSpec>
+        <!--2025-12-16 (TT) Simplified to avoid errors in XSD -->
+        <elementSpec ident="list" mode="change">
+            <content>
+                <sequence>
+                    <alternate minOccurs="0" maxOccurs="unbounded">
+                        <classRef key="model.divTop"/>
+                        <classRef key="model.global"/>
+                        <elementRef key="desc" minOccurs="0" maxOccurs="unbounded"/>
+                    </alternate>
+                    <sequence minOccurs="1" maxOccurs="unbounded">
+                        <elementRef key="item"/>
+                        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                    <sequence minOccurs="0" maxOccurs="unbounded">
+                        <classRef key="model.divBottom"/>
+                        <classRef key="model.global" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </sequence>
             </content>
         </elementSpec>
         <elementSpec ident="listBibl" mode="change">
@@ -635,6 +664,11 @@
                     entries, senses, examples etc.</p>
             </remarks>
         </elementSpec>
+        <elementSpec ident="metamark" mode="change">
+            <content>
+                <textNode/>
+            </content>
+        </elementSpec>
         <elementSpec ident="name" mode="change">
             <classes mode="change">
                 <memberOf key="model.languageProfile" mode="add"/>
@@ -644,6 +678,9 @@
             <classes mode="change">
                 <memberOf key="model.languageProfile" mode="add"/>
             </classes>
+            <content>
+                <macroRef key="macro.lexSpecialPara"/>
+            </content>
         </elementSpec>
         <!--2020-06-25 (TT): num, to be used strictly for numbering entries and senses -->
         <elementSpec ident="num" mode="change">
@@ -657,13 +694,14 @@
             </content>
         </elementSpec>
         <!--2020-05-14 add orth and pron to att.datable.w3c to allow @notBefore etc.-->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="orth" mode="change">
             <classes mode="change">
                 <memberOf key="att.datable.w3c" mode="add"/>
+                <memberOf key="model.lexFormPart" mode="add"/>
             </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
         </elementSpec>
         <elementSpec ident="person" mode="change">
@@ -682,13 +720,14 @@
                 <classRef key="model.profileDescPart" minOccurs="1" maxOccurs="unbounded"/>
             </content>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="pron" mode="change">
             <classes mode="change">
                 <memberOf key="att.datable.w3c" mode="add"/>
+                <memberOf key="model.lexFormPart" mode="add"/>
             </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
         </elementSpec>
         <!--2021-09-20 (TT): make availability required in publicationStmt-->
@@ -697,13 +736,21 @@
             for encoding rights holders-->
         <elementSpec ident="publicationStmt" mode="change">
             <content>
-                <sequence>
+                <alternate minOccurs="1" maxOccurs="unbounded">
                     <classRef key="model.publicationStmtPart.agency" minOccurs="1"
                         maxOccurs="unbounded"/>
-                    <classRef key="model.publicationStmtPart.detail" minOccurs="0"
-                        maxOccurs="unbounded"/>
-                    <elementRef key="availability"/>
-                </sequence>
+                    <!--deconstruct model.publicationStmtPart.detail so that we can require availability
+                    this was causing errors as per Github Issue #233.-->
+                    <!--<classRef key="model.publicationStmtPart.detail" minOccurs="0"
+                        maxOccurs="unbounded"/>-->
+                    <!--TODO: delve deeper into publicationStmt, we could, potentially make some elements
+                    other than availability required here, but i don't want to rush-->
+                    <elementRef key="availability" minOccurs="1"/>
+                    <classRef key="model.ptrLike" minOccurs="0"/>
+                    <elementRef key="date" minOccurs="0"/>
+                    <elementRef key="idno" minOccurs="0"/>
+                    <elementRef key="pubPlace" minOccurs="0"/>
+                </alternate>
             </content>
         </elementSpec>
         <elementSpec ident="purpose" mode="change">
@@ -711,8 +758,13 @@
                 <memberOf key="model.languageProfile" mode="add"/>
             </classes>
         </elementSpec>
+        <elementSpec ident="quote" mode="change">
+            <content>
+                <macroRef key="macro.lexSpecialPara"/>
+            </content>
+        </elementSpec>
         <!-- 2018-09-1 (LR): the <ref> element is adapted to have specific @type values (semi-closed) -->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="ref" mode="change">
             <!--2020-05-14 (TT): to allow expand on ref-->
             <classes mode="change">
@@ -723,7 +775,7 @@
                 <memberOf key="att.scoped"/>
             </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
             <attList>
                 <attDef ident="type" mode="replace" usage="req">
@@ -739,16 +791,16 @@
                 </attDef>
             </attList>
         </elementSpec>
-        <!--2025-11-29 (TT): model.lexicalPhrase is a paired-down model.phrase for dictionaries-->
+        <!--2025-11-29 (TT): model.lexPhrase is a paired-down model.phrase for dictionaries-->
         <elementSpec ident="ruby" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase" mode="add"/>
+                <memberOf key="model.lexPhrase" mode="add"/>
             </classes>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="seg" mode="change">
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
         </elementSpec>
         <!-- 2018-09-03 (LR): making @xml:id mandatory on sense -->
@@ -764,8 +816,8 @@
                     <!--<elementRef key="sense"/>
                                 -->
                     <classRef key="model.sensePart"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.global"/>
+                    <!--<classRef key="model.lexPhrase"/>
+                    <classRef key="model.global"/>-->
                 </alternate>
             </content>
             <attList>
@@ -807,16 +859,22 @@
                 </egXML>
             </exemplum>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="stress" mode="change">
+            <classes>
+                <memberOf key="model.lexFormPart" mode="add"/>
+            </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="syll" mode="change">
+            <classes>
+                <memberOf key="model.lexFormPart" mode="add"/>
+            </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
         </elementSpec>
         <!--2023-04-20 (TT) make type mandatory on TEI-->
@@ -843,18 +901,19 @@
                 </sequence>
             </content>
         </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <!--2023-01-23 (TT): change content model to macro.lexParaContent-->
         <elementSpec ident="title" mode="change">
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
             <attList>
                 <attDef ident="type" mode="replace" usage="rec">
                     <valList>
                         <valItem ident="full">
-                            <desc>The full title of a lexicographic resource, such as <egXML 
+                            <desc>The full title of a lexicographic resource, such as <egXML
                                     xmlns="http://www.tei-c.org/ns/Examples">
-                                    <title type="full">The Oxford English Dictionary</title></egXML>.</desc>
+                                    <title type="full">The Oxford English
+                                Dictionary</title></egXML>.</desc>
                         </valItem>
                         <valItem ident="abbr">
                             <desc>The preferred abbreviated title of a lexicographic resource, such
@@ -867,11 +926,8 @@
         </elementSpec>
         <!-- 2018-07-17 (TT): the <usg> element is adapted to have specific @type values -->
         <elementSpec ident="usg" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-            </classes>
             <content>
-                <macroRef key="macro.lexicalParaContent"/>
+                <macroRef key="macro.lexParaContent"/>
             </content>
             <attList>
                 <attDef ident="type" mode="replace" usage="req">
@@ -937,21 +993,17 @@
         <!-- made member of att.notated (for having @notation) ==> to be discussed -->
         <elementSpec ident="xr" mode="change">
             <classes mode="change">
+                <!--TODO: I'm moving xr to lexPhrase to see if that works better-->
+                <!--<memberOf key="model.quoteLike" mode="add"/>-->
+                <!--gives me problems in dictScrap b/c it's also a member for entryPart-->
+                <!--<memberOf key="model.lexPhrase" mode="add"></memberOf>-->
                 <memberOf key="model.sensePart" mode="add"/>
-                <!-- 2018-12-04 [LR] to have <xr> in <def> and few other cool places -->
-                <!-- 2019-10-22 [LR] deleted to prevent ambiguous content model -->
-                <!--<memberOf key="model.emphLike" mode="add"/>-->
-                <!--<classes mode="change">
-                            <memberOf key="att.notated" mode="add"/>
-                        </classes>-->
-                <!--2020-05-14 allow inside quote (for cross-references in examples)-->
-                <memberOf key="model.quoteLike" mode="add"/>
             </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
                     <classRef key="model.gLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
+                    <classRef key="model.lexPhrase"/>
+                    <classRef key="model.lexInter"/>
                     <elementRef key="usg"/>
                     <elementRef key="lbl"/>
                     <classRef key="model.global"/>
@@ -1026,102 +1078,114 @@
                 </attDef>
             </attList>
         </elementSpec>
-        
         <!-- ========================================================= -->
         <!-- SECTION: CLASSES                                          -->
         <!-- ========================================================= -->
-
+        <!-- Members: model.quoteLike[cit quote]-->
         <classSpec ident="model.attributable" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalInter"/>
+                <memberOf key="model.lexInter"/>
             </classes>
         </classSpec>
-
-        <!-- Making model.biblLike member of model.entryPart.top so that <bibl> is available in <entry> -->
+        <!-- Members: `bibl` `biblStruct` `listBibl`-->
         <classSpec ident="model.biblLike" type="model" mode="change">
             <classes mode="change">
                 <memberOf key="model.entryPart.top" mode="add"/>
+                <memberOf key="model.lexInter" mode="add"/>
             </classes>
         </classSpec>
-
-        <classSpec ident="model.biblLike" type="model" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalInter"/>
+        <!-- Members: `model.noteLike[note]` `figure` `metamark` -->
+        <classSpec ident="model.global" type="model" mode="change">
+            <classes>
+                <memberOf key="model.sensePart" mode="add"/>
             </classes>
         </classSpec>
-
-        <classSpec ident="model.graphicLike" type="model" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalPhrase"/>
-            </classes>
-        </classSpec>
-
-        <classSpec ident="model.highlighted" type="model" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalPhrase"/>
-            </classes>
-        </classSpec>
-
+        <!-- Members: `hi` -->
         <classSpec ident="model.hiLike" type="model" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalPhrase"/>
+            <classes>
+                <memberOf key="model.lexPhrase"/>
             </classes>
         </classSpec>
-
         <!-- 2023-11-27 (TT) model.languageProfile-->
+        <!-- Members: `bibl` `channel` `date` `desc` `domain` `ident` `interaction` `listBibl` 
+             `name` `note` `person` `personGrp` `purpose` `settingDesc` -->
         <classSpec ident="model.languageProfile" type="model">
             <desc> Groups all elements used to describe a language or language variety: identifiers,
                 names, space/time metadata, social and personal characteristics, medium, and
                 communicative functioning, following ISO 21636. </desc>
         </classSpec>
-
-        <!--2023-01-24 (TT): create model.lexicalInter to simplify content models of certain
+        <!-- Members: [`gloss`] -->
+        <!-- Original: [`model.emphLike`[`gloss` `ident` `lbl` `term` `title`]-->
+        <classSpec ident="model.lexEmphLike" type="model" mode="add">
+            <classes>
+                <memberOf key="model.lexPhrase"/>
+            </classes>
+        </classSpec>
+        <!-- had to recreate because the original formPart inherited subclass morphLike[`gram`]-->
+        <!-- Members: `model.lexicalRefinement`[`gramGrp` `lbl` `usg`] `form` `hyph` `orth` `pron` 
+             `stress` `syll` -->
+        <classSpec ident="model.lexFormPart" type="model" mode="add">
+            <desc> groups elements allowed within a <gi>form</gi> element in a dictionary. </desc>
+        </classSpec>
+        <!--2023-01-24 (TT): create model.lexInter to simplify content models of certain
         dictionary elements -->
-        <classSpec ident="model.lexicalInter" type="model" mode="add">
+        <classSpec ident="model.lexInter" type="model" mode="add">
             <desc> pared-down version of model.inter for use in dictionary elements </desc>
         </classSpec>
-
-        <!-- 2023-04-22 (TT) -->
-        <classSpec ident="model.lexicalPhrase" type="model" mode="add">
-            <desc> pared-down version of model.phrase for use in dictionary elements </desc>
+        <!--Members: ´gramGrp´ ´lbl´ ´usg´-->
+        <classSpec ident="model.lexicalRefinement" type="model" mode="change">
+            <classes>
+                <memberOf key="model.lexFormPart" mode="add"/>
+                <memberOf key="model.formPart" mode="delete"/>
+                <memberOf key="model.sensePart"/>
+            </classes>
         </classSpec>
-
+        <!-- 2023-04-22 (TT) -->
+        <!-- Members: ´model.attributable´[´model.quoteLike´[´cit´ ´quote´]] 
+             ´model.biblLike´[´bibl´ ´biblStruct´ ´listBibl´] -->
+        <classSpec ident="model.lexPhrase" type="model" mode="add">
+            <desc> pared-down version of model.phrase for use in dictionary elements </desc>
+            <classes>
+                <memberOf key="model.sensePart"/>
+            </classes>
+        </classSpec>
         <!--  we're not linlcuding model.nameLike because then we get a bunch
         of name,orgName,persName,placeName elements etc. inside form,
         orth etc. We do need lang, which is also a member of model.nameLike. 
-        We're solving this by making lang a member of model.lexicalPhrase directly-->
+        We're solving this by making lang a member of model.lexPhrase directly-->
         <!--<classSpec type="model" ident="model.nameLike" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase"></memberOf>
+                <memberOf key="model.lexPhrase"></memberOf>
             </classes>
         </classSpec>-->
-
         <!--we are not including model.pPart.edit [model.pPart.editorial 
         [abbr am choice ex expan subst] because we don't want to
         introduce abbr, am etc. in a bunch of lexicographic elements, 
         but when we decide to include choice, we'll have to add it 
         on its own here -->
+        <!-- Members: ´ref´-->
         <classSpec ident="model.ptrLike" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase"/>
+                <memberOf key="model.lexPhrase"/>
             </classes>
         </classSpec>
-
+        <!-- Members: ´c´ ´pc´ ´seg´-->
         <classSpec ident="model.segLike" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase"/>
+                <memberOf key="model.lexPhrase"/>
             </classes>
         </classSpec>
-
+        <!-- Members: model.global[model.global.edit model.global.meta model.milestoneLike 
+        model.noteLike[note] figure metamark] model.lexPhrase[model.hiLike[hi] model.lexEmphLike[gloss] 
+        model.ptrLike[ref] model.segLike[c pc seg] lang ruby] model.lexicalRefinement[gramGrp lbl usg] 
+        cit def entry etym form num sense xr -->
         <classSpec ident="model.sensePart" type="model">
             <desc>groups together all the elements from the dictionary modules that can appear as
                 child of <gi>sense</gi></desc>
         </classSpec>
-  
         <!-- ========================================================= -->
         <!-- SECTION: ATTRIBUTES                                       -->
         <!-- ========================================================= -->
-        
         <!--2018-09-02 (TT): Added PB's useful class modifications-->
         <!-- three of the TEI attribute classes are simplified. The attributes xml:space,
                         rend are removed from the att.global class, so that this now makes available
@@ -1194,37 +1258,42 @@
                 </attDef>
             </attList>
         </classSpec>
-        
         <!-- ========================================================= -->
         <!-- SECTION: MACROS                                           -->
         <!-- ========================================================= -->
-        
-        <!-- 2019-10-22 (LR) new hack to have <xr> in <def> and similar places -->
-        <!-- 2023-01-24 (TT) retired this customization because now we have macro.lexicalParaContent -->
-        <!--<macroSpec ident="macro.paraContent" mode="change">
+        <macroSpec ident="macro.lexParaContent" mode="add">
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
                     <textNode/>
                     <classRef key="model.gLike"/>
-                    <classRef key="model.phrase"/>
-                    <classRef key="model.inter"/>
+                    <classRef key="model.lexPhrase"/>
+                    <!--<classRef key="model.lexInter"/>-->
                     <classRef key="model.global"/>
-                    <elementRef key="lg"/>
-                    <classRef key="model.lLike"/>
-                    <elementRef key="xr"/>
+                    <!--<elementRef key="lg"/>-->
+                    <!--<classRef key="model.lLike"/>-->
+                    <!--<elementRef key="xr"/>-->
                 </alternate>
             </content>
-        </macroSpec>-->
-        <macroSpec ident="macro.lexicalParaContent" mode="add">
+        </macroSpec>
+        <!-- macro.specialPara: [`change` `item` `licence` `metamark` `occupation` `quote`] -->
+        <!-- macro.lexSpecialPara: [ `quote` `def`] -->
+        <macroSpec ident="macro.lexSpecialPara" mode="add">
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
                     <textNode/>
                     <classRef key="model.gLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.global"/>
-                    <elementRef key="lg"/>
-                    <classRef key="model.lLike"/>
+                    <!--<classRef key="model.phrase"/>-->
+                    <!--<classRef key="model.inter"/>-->
+                    <!--<classRef key="model.lexInter"/>-->
+                    <!--<classRef key="model.lexPhrase"/>-->
+                    <classRef key="model.hiLike"/>
+                    <!--<classRef key="model.global"/>-->
+                    <!--<elementRef key="lg"/>-->
+                    <!--<classRef key="model.lLike"/>-->
+                    <classRef key="model.ptrLike"/> <!--[`ref`]-->
+                    <classRef key="model.segLike"/> <!--[`c` `pc` `seg`]-->
+                    <elementRef key="gloss"/>
+                    <elementRef key="ruby"/>
                     <elementRef key="xr"/>
                 </alternate>
             </content>

--- a/Schemas/TEILex0/TEILex0.parts/40__specification.xml
+++ b/Schemas/TEILex0/TEILex0.parts/40__specification.xml
@@ -5,15 +5,16 @@
     xml:id="specification">
     <head>Specification</head>
     <schemaSpec ident="TEILex0" docLang="en" xml:lang="en">
-        <moduleRef key="gaiji" except="localName"/>
+        
+        <!-- ========================================================= -->
+        <!-- SECTION: MODULES                                          -->
+        <!-- ========================================================= -->
+        
+        <!--2018-09-11 (TT): this is superflous because we're removing all
+        elements from analysis -->
+        <moduleRef key="analysis" except="cl interp interpGrp m phr s span spanGrp w"/>
         <!-- 2018-09-02 (TT): changed moduleRef for linking based on PB -->
-        <moduleRef key="linking" include="seg"/>
-        <!-- for segmentation inside orth/pron -->
-        <!-- 2018-09-02 (TT): removed re hom -->
-        <!-- 2018-09-02 (TT): put dictScrap back, I think we still want it -->
-        <!-- 2020-07-06 (TT): removing unnecessary gramatical elements + oRef and pRef (for which we use ref) -->
-        <moduleRef key="dictionaries"
-            except="entryFree superEntry re hom case colloc gen iType mood number oRef pRef per pos subc tns"/>
+        <moduleRef key="gaiji" except="localName"/>
         <!-- 2018-09-02 (TT): explicitly encoded what we allow from core -->
         <!-- 2018-09-11 (TT): removed list, item and label because i don't
                     see them as lexicographically relevant. I don't thin we need p either
@@ -26,54 +27,169 @@
         <!--2025-11-29 (TT): added ruby-->
         <!--2025-12-06 (TT): added measure as per https://github.com/DARIAH-ERIC/lexicalresources/issues/257 -->
         <moduleRef key="core"
-            include="author head title cit quote bibl biblStruct biblScope listBibl gloss
-                        citedRange imprint analytic monogr publisher pubPlace ref date hi editor respStmt name num resp term note graphic p email list item abbr expan desc ruby rb rt measure"/>
-        <!--PB's simplified textstructure declaratiopn-->
-        <moduleRef key="textstructure" include="TEI text body div front back"/>
+            include="abbr analytic author bibl biblScope biblStruct cit citedRange date desc
+            editor email expan gloss graphic head hi imprint item list listBibl measure
+            monogr name num p pubPlace publisher quote rb ref resp respStmt rt ruby term
+            title"/>
+        <!-- 2020-11-27 (TT): for language profiles -->
+        <moduleRef key="corpus" include="channel domain interaction purpose settingDesc"/>
+        <!-- 2018-09-02 (TT): removed re hom -->
+        <!-- 2018-09-02 (TT): put dictScrap back, I think we still want it -->
+        <!-- 2020-07-06 (TT): removing unnecessary gramatical elements + oRef and pRef (for which we use ref) -->
+        <moduleRef key="dictionaries"
+            except="case colloc entryFree gen hom iType mood number oRef pRef per
+            pos re subc superEntry tns"/>
         <!-- 2018-09-11 (TT): 2018-09-11 (TT): Some dictionaries use images, hence
                     leaving this here. Also head (from the core module is needed if we have images
                     with explicit titles as opposed to captions. This we will come back to of course.-->
         <moduleRef key="figures" include="figDesc figure"/>
-        <!--2018-09-11 (TT): this is superflous because we're removing all elements
-                    from analysis -->
-        <moduleRef key="analysis" except="cl interp interpGrp m phr s span spanGrp w"/>
-        <!--<moduleRef key="iso-fs" except="bicond binary cond default fDecl fDescr fLib fsConstraints fsDecl fsDescr fsdDecl fsdLink fvLib if iff numeric then vAlt vColl vDefault"/>
-                    -->
         <!-- 2018-09-02 (TT): added PB's simplified declaration of the header and namesdates -->
         <!--2020-06-23 (TT): add profileDesc so that we can document langUsage-->
         <!--2021-09-25 (TT): add xenoData and revisionDesc-->
         <!--2022-03-24 (TT): add taxonomy-->
         <moduleRef key="header"
-            include="teiHeader fileDesc profileDesc titleStmt editionStmt extent publicationStmt sourceDesc encodingDesc revisionDesc xenoData editorialDecl projectDesc seriesStmt
-            notesStmt authority distributor idno edition availability licence appInfo classDecl namespace tagUsage tagsDecl rendition taxonomy category catDesc change principal language"/>
+            include="appInfo authority availability catDesc category classDecl change edition editionStmt
+            editorialDecl encodingDesc extent fileDesc idno language langUsage licence namespace notesStmt
+            principal projectDesc profileDesc publicationStmt revisionDesc rendition seriesStmt
+            sourceDesc tagUsage tagsDecl taxonomy teiHeader titleStmt xenoData"/>
+        <!--<moduleRef key="iso-fs" except="bicond binary cond default fDecl fDescr fLib fsConstraints fsDecl fsDescr fsdDecl fsdLink fvLib if iff numeric then vAlt vColl vDefault"/>
+                    -->
+        <!-- for segmentation inside orth/pron -->
+        <moduleRef key="linking" include="seg"/>
         <!--2020-05-24 (TT): added persName and orgName; need them for bibliographies-->
-        <!--        2021-09-19 (TT): added forename, surname; need for detailed biblStruct/author/persName-->
-        <!--        2021-11-27 (TT): added a bunch of elements from model.persStateLike for language profiles-->
-        <moduleRef key="namesdates" include="placeName persName orgName forename surname place person personGrp affiliation age education faith floruit gender langKnowledge langKnown nationality occupation persName persPronouns persona residence sex socecStatus state trait"/>
-        <!--2020-11-27 (TT): added ident, channel, interaction, domain, purpose, settingDesc needed for language profiles -->
+        <!-- 2021-09-19 (TT): added forename, surname; need for detailed biblStruct/author/persName-->
+        <!-- 2021-11-27 (TT): added a bunch of elements from model.persStateLike for language profiles-->
+        <moduleRef key="namesdates"
+            include="affiliation age education faith floruit forename gender langKnowledge langKnown
+            nationality occupation orgName person personGrp persona persName persPronouns place
+            placeName residence sex socecStatus state surname trait"/>
+        <!-- 2020-11-27 (TT): added ident, needed for language profiles -->
         <moduleRef key="tagdocs" include="ident"/>
-        <moduleRef key="corpus" include="channel interaction domain purpose settingDesc"/>
-        <!-- for dialectal properties -->
         <moduleRef key="tei" except="correspAction correspContext correspDesc"/>
+        <!--PB's simplified textstructure declaratiopn-->
+        <moduleRef key="textstructure" include="back body div front TEI text"/>
         <!-- LR (2019-11-14) Adding the transc module just to have metamark - as discussed with TT at the DH master class in FU Berlin-->
         <moduleRef key="transcr" include="metamark"/>
         
+        <!-- ========================================================= -->
+        <!-- SECTION: ELEMENTS                                         -->
+        <!-- ========================================================= -->
+        
+        <!--2021-09-21 (TT): add @role to authority so that we can specify
+        what kind of authority we're talking about; for instance 
+        <authority role="rightsHolder"></authority>-->
+        <elementSpec ident="authority" mode="change">
+            <attList>
+                <attDef ident="role" mode="add">
+                    <valList mode="add" type="semi">
+                        <valItem ident="funder"/>
+                        <valItem ident="sponsor"/>
+                        <valItem ident="rightsHolder"/>
+                    </valList>
+                </attDef>
+            </attList>
+        </elementSpec>
+        <elementSpec ident="bibl" mode="change">
+            <!--2025-11-27 (TT): added to to model.languageProfile-->
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
         <elementSpec ident="catDesc" mode="change">
             <content>
                 <sequence>
                     <elementRef key="term"/>
                     <elementRef key="gloss" minOccurs="0" maxOccurs="1"/>
-                </sequence>   
+                </sequence>
             </content>
         </elementSpec>
-        
         <elementSpec ident="category" mode="change">
             <classes mode="change">
-                <memberOf key="att.datcat"></memberOf>
+                <memberOf key="att.datcat"/>
             </classes>
         </elementSpec>
-        
-        
+        <elementSpec ident="channel" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!-- adding cit to model.sensePart -->
+        <elementSpec ident="cit" mode="change">
+            <classes mode="change">
+                <memberOf key="model.sensePart" mode="add"/>
+            </classes>
+            <content>
+                <alternate minOccurs="1" maxOccurs="unbounded">
+                    <classRef key="model.quoteLike"/>
+                    <classRef key="model.egLike"/>
+                    <classRef key="model.biblLike"/>
+                    <classRef key="model.ptrLike"/>
+                    <classRef key="model.global"/>
+                    <classRef key="model.entryPart"/>
+                    <!-- 2019-06-25 (TT): adding  model.segLike to allow pc etc. in cit -->
+                    <classRef key="model.segLike"/>
+                    <!-- 2019-10-22 (LR): adding <lang> to deal with etymological descriptions -->
+                    <elementRef key="lang"/>
+                    <!-- 2019-11-20 (LR): adding <gloss> to deal with etymological descriptions -->
+                    <elementRef key="gloss"/>
+                </alternate>
+            </content>
+            <attList>
+                <attDef ident="type" mode="replace" usage="req">
+                    <valList type="closed" mode="change">
+                        <valItem ident="example"/>
+                        <valItem ident="translation"/>
+                        <valItem ident="translationEquivalent"/>
+                        <valItem ident="etymon"/>
+                        <valItem ident="cognate"/>
+                        <valItem ident="cognateSet"/>
+                    </valList>
+                </attDef>
+            </attList>
+        </elementSpec>
+        <elementSpec ident="date" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!-- adding def to model.sensePart -->
+        <!--2020-06-30 (TT): def is only allowed within a sense!-->
+        <!--TODO: at the moment, it's still allowed in etym, but it shouldn't be
+        because if there is no sense, we have to use gloss. fix later-->
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="def" mode="change">
+            <classes mode="change">
+                <memberOf key="model.sensePart" mode="add"/>
+                <memberOf key="model.entryPart.top" mode="delete"/>
+                <memberOf key="model.entryPart" mode="delete"/>
+            </classes>
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <elementSpec ident="desc" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <elementSpec ident="dictScrap" mode="change">
+            <content>
+                <alternate minOccurs="0" maxOccurs="unbounded">
+                    <textNode/>
+                    <classRef key="model.gLike"/>
+                    <classRef key="model.entryPart"/>
+                    <classRef key="model.morphLike"/>
+                    <classRef key="model.lexicalPhrase"/>
+                    <classRef key="model.lexicalInter"/>
+                    <classRef key="model.global"/>
+                </alternate>
+            </content>
+        </elementSpec>
+        <elementSpec ident="domain" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
         <!-- Initial change to make entry recursive (LR) -->
         <!-- 2018-09-03 (LR): making @xml:id required -->
         <elementSpec ident="entry" mode="change">
@@ -108,120 +224,492 @@
                 </attDef>
             </attList>
         </elementSpec>
-        <!-- 2018-09-03 (LR): making @xml:id mandatory on sense -->
-        <elementSpec ident="sense" mode="change">
+        <!-- adding etym to model.sensePart -->
+        <elementSpec ident="etym" mode="change">
             <classes mode="change">
                 <memberOf key="model.sensePart" mode="add"/>
             </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
-                    <!-- 2019-06-25 (TT): removed <textNode/> because we don't mixed content in sense-->
+                    <textNode/>
                     <classRef key="model.gLike"/>
-                    <!-- following line useless since sense is member of model.sensePart -->
-                    <!--<elementRef key="sense"/>
-                                -->
-                    <classRef key="model.sensePart"/>
-                    <classRef key="model.lexicalPhrase"/>
                     <classRef key="model.global"/>
+                    <classRef key="model.lexicalInter"/>
+                    <classRef key="model.lexicalPhrase"/>
+                    <classRef key="model.descLike"/>
+                    <elementRef key="def"/>
+                    <elementRef key="etym"/>
+                    <elementRef key="gramGrp"/>
+                    <elementRef key="lbl"/>
+                    <elementRef key="usg"/>
+                    <elementRef key="xr"/>
                 </alternate>
             </content>
             <attList>
-                <attDef ident="xml:id" mode="change" usage="req"/>
-                <attDef ident="level" mode="delete"/>
+                <attDef ident="type" mode="replace" usage="rec">
+                    <valList type="closed" mode="change">
+                        <valItem ident="borrowing"/>
+                        <valItem ident="inheritance"/>
+                        <valItem ident="metaphor"/>
+                        <valItem ident="metonymy"/>
+                        <valItem ident="compounding"/>
+                        <valItem ident="grammaticalization"/>
+                        <valItem ident="derivation"/>
+                    </valList>
+                </attDef>
             </attList>
         </elementSpec>
-        <!-- 2018-07-17 (LR): the <xr> element is adapted to have specific @type values -->
-        <!-- implemented default value to lexical -->
-        <!-- introducing @subtype (note to myself: make feature request to TEI so that xr belongs to att.typed -->
-        <!-- made member of att.notated (for having @notation) ==> to be discussed -->
-        <elementSpec ident="xr" mode="change">
+        <elementSpec ident="extent" mode="change">
+            <content>
+                <elementRef key="measure" minOccurs="1" maxOccurs="unbounded"/>
+            </content>
+            <exemplum versionDate="2016-11-04" xml:lang="en">
+                <p>The <gi>extent</gi> element may be used to supply normalized or machine tractable
+                    versions of the size or sizes concerned.</p>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-extent-egXML-ig">
+                    <extent>
+                        <measure unit="MiB" quantity="4.2">About four megabytes</measure>
+                        <measure unit="pages" quantity="245">245 pages of source material</measure>
+                    </extent>
+                </egXML>
+            </exemplum>
+            <exemplum versionDate="2025-12-07" xml:lang="en">
+                <p>The <gi>extent</gi> element may be used to supply statistical information about a
+                    given dictionary.</p>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-extent-egXML-si">
+                    <fileDesc>
+                        <!-- ... -->
+                        <extent>
+                            <measure unit="entries" quantity="15,306"/>
+                            <measure unit="senses" quantity="46,558"/>
+                        </extent>
+                    </fileDesc>
+                </egXML>
+            </exemplum>
+        </elementSpec>
+        <!-- 2021-09-26 (TT): dont't require sourceDesc in fileDesc; we want it 
+        only if we can provide a proper biblStruct for it; otherwise, it's useless
+        (i.e. we don't want <sourceDesc><p>Born digital</p></sourceDesc> -->
+        <elementSpec ident="fileDesc" mode="change">
+            <content>
+                <sequence>
+                    <sequence>
+                        <elementRef key="titleStmt"/>
+                        <elementRef key="editionStmt" minOccurs="0"/>
+                        <elementRef key="extent" minOccurs="0"/>
+                        <elementRef key="publicationStmt"/>
+                        <elementRef key="seriesStmt" minOccurs="0" maxOccurs="unbounded"/>
+                        <elementRef key="notesStmt" minOccurs="0"/>
+                    </sequence>
+                    <elementRef key="sourceDesc" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </content>
+        </elementSpec>
+        <!-- adding form to model.sensePart -->
+        <elementSpec ident="form" mode="change">
             <classes mode="change">
                 <memberOf key="model.sensePart" mode="add"/>
-                <!-- 2018-12-04 [LR] to have <xr> in <def> and few other cool places -->
-                <!-- 2019-10-22 [LR] deleted to prevent ambiguous content model -->
-                <!--<memberOf key="model.emphLike" mode="add"/>-->
-                <!--<classes mode="change">
-                            <memberOf key="att.notated" mode="add"/>
-                        </classes>-->
-                <!--2020-05-14 allow inside quote (for cross-references in examples)-->
-                <memberOf key="model.quoteLike" mode="add"/>
             </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
+                    <textNode/>
                     <classRef key="model.gLike"/>
                     <classRef key="model.lexicalPhrase"/>
                     <classRef key="model.lexicalInter"/>
-                    <elementRef key="usg"/>
-                    <elementRef key="lbl"/>
+                    <classRef key="model.formPart"/>
                     <classRef key="model.global"/>
                 </alternate>
             </content>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="gram" mode="change">
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
             <attList>
                 <attDef ident="type" mode="replace" usage="req">
-                    <defaultVal>related</defaultVal>
-                    <valList type="closed" mode="change">
-                        <!-- 2018-12-06-->
-                        <!--<valItem ident="crossReference"/>-->
-                        <valItem ident="synonymy">
-                            <desc>Relation between two lexical units X and Y which are syntactically
-                                identical and have the property that any declarative sentence S
-                                containing X has equivalent truth conditions to another sentence S’
-                                which is identical to S, except that X is replaced by Y. (Adapted
-                                from Cruse (1986).)</desc>
-                            <remarks>
-                                <p>Synonymy is the linguistic parallel of the identity relation
-                                    between classes. Synonyms differ in peripheral traits, related
-                                    for example to stylistic, dialectal or diachronic
-                                    variations.</p>
-                                <p>Examples: [de] {Hund, Köter}, [en] {flashlight, torch}, [en]
-                                    {glad, joyful, happy}, [en] {violin, fiddle} [en] He plays the
-                                    violin very well/He plays the fiddle very well.</p>
-                            </remarks>
+                    <valList type="semi" mode="change">
+                        <valItem ident="pos">
+                            <equiv name="pos"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-pos.html"
+                            />
                         </valItem>
-                        <valItem ident="hyponymy">
-                            <desc> Relation between lexical units X and Y characterised by the
-                                property that the sentence ‘This is a(n) X’ entails, but is not
-                                entailed by the sentence ‘This is a(n) Y’. (Adapted from Cruse (1986).) </desc>
-                            <remarks>
-                                <p>Hyponymy and its converse hypernymy are the linguistic parallels
-                                    of the relation of inclusion between two classes.</p>
-                                <p>Examples: [en] animal/dog, red/scarlet, to kill/to murder</p>
-                                <p>[en] This is a dog. => This is an animal.</p>
-                                <p>[en] This is a scarlet flower. => This is a red flower.</p>
-                            </remarks>
+                        <valItem ident="aspect"/>
+                        <valItem ident="case">
+                            <equiv name="case"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-case.html"
+                            />
                         </valItem>
-                        <valItem ident="hypernymy">
-                            <desc>Relation between lexical heads X and Y characterised by the
-                                property that the sentence ‘This is a(n) Y’ entails, but is not
-                                entailed by the sentence ‘This is a(n) X’. (Adapted from Cruse (1986).) </desc>
-                            <remarks>
-                                <p>Hypernymy is the converse of hyponymy.</p>
-                                <p> Example: dog/animal (animal is a hypernym of dog)</p>
-                            </remarks>
+                        <valItem ident="construction"/>
+                        <valItem ident="degree"/>
+                        <valItem ident="gender">
+                            <equiv name="gen"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-gen.html"
+                            />
                         </valItem>
-                        <valItem ident="meronymy">
-                            <desc>An inclusion relation between lexical heads X and Y which reflect
-                                a potential part-whole relation between their referents in
-                                discourse. (Adapted from Cruse (2011, p. 140).)</desc>
-                            <remarks>
-                                <p>Example: finger:hand (finger is said to be a meronym of hand, and
-                                    hand is said to be the holonym of finger).</p>
-                            </remarks>
+                        <valItem ident="inflectionType">
+                            <equiv name="iType"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-iType.html"
+                            />
                         </valItem>
-                        <valItem ident="antonymy"/>
-                        <valItem ident="related">
-                            <desc>The default reference to another lexical unit when no additional
-                                information is available.</desc>
+                        <valItem ident="mood">
+                            <equiv name="mood"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-mood.html"
+                            />
                         </valItem>
-                        <!-- further values to be added there -->
+                        <valItem ident="number">
+                            <equiv name="number"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-number.html"
+                            />
+                        </valItem>
+                        <valItem ident="tense">
+                            <equiv name="tns"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-tns.html"
+                            />
+                        </valItem>
+                        <valItem ident="valency"/>
+                        <valItem ident="collocate">
+                            <equiv name="colloc"
+                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-colloc.html"
+                            />
+                        </valItem>
                     </valList>
                 </attDef>
-                <attDef ident="subtype" mode="replace" usage="opt">
-                    <datatype>
-                        <dataRef key="teidata.enumerated"/>
-                    </datatype>
+            </attList>
+        </elementSpec>
+        <!-- adding gramGrp to model.sensePart -->
+        <elementSpec ident="gramGrp" mode="change">
+            <classes mode="change">
+                <memberOf key="model.sensePart" mode="add"/>
+            </classes>
+            <content>
+                <alternate minOccurs="0" maxOccurs="unbounded">
+                    <textNode/>
+                    <classRef key="model.gLike"/>
+                    <classRef key="model.lexicalPhrase"/>
+                    <classRef key="model.lexicalInter"/>
+                    <classRef key="model.gramPart"/>
+                    <classRef key="model.global"/>
+                </alternate>
+            </content>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="hyph" mode="change">
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <elementSpec ident="ident" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <elementSpec ident="interaction" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!-- adding lang to model.entryPart (to make it member of <cit>, if you ask) -->
+        <!-- 2019-10-22 (LR) created ambiguous models... mended -->
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="lang" mode="change">
+            <!--<classes mode="change">
+                            <memberOf key="model.entryPart" mode="add"/>
+                        </classes>-->
+            <classes mode="change">
+                <!--because we don't use model.nameLike in model.lexicalPhrase-->
+                <memberOf key="model.lexicalPhrase" mode="add"/>
+            </classes>
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+            <exemplum>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="d1e5322">
+                    <cit type="cognate">
+                        <lang>dän.</lang>
+                        <form>
+                            <orth xml:lang="da">indgang</orth>
+                        </form>
+                    </cit>
+                </egXML>
+            </exemplum>
+            <exemplum>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="d1e5340">
+                    <cit type="etymon">
+                        <lang>mhd.</lang>
+                        <form type="variant">
+                            <orth xml:lang="gmh">vreten</orth>
+                        </form>
+                        <form type="variant">
+                            <orth xml:lang="gmh">vretten</orth>
+                        </form>
+                        <form type="variant">
+                            <orth xml:lang="gmh">vraten</orth>
+                        </form>
+                        <gloss>entzünden</gloss><pc>;</pc>
+                        <gloss>wundreiben</gloss><pc>;</pc>
+                        <gloss>herumziehen</gloss><pc>;</pc>
+                        <gloss>quälen</gloss><pc>;</pc>
+                        <gloss>plagen</gloss>
+                    </cit>
+                </egXML>
+            </exemplum>
+        </elementSpec>
+        <elementSpec ident="language" mode="change">
+            <classes mode="replace">
+                <memberOf key="att.global.rendition" mode="delete"/>
+                <memberOf key="att.global.linking" mode="delete"/>
+                <memberOf key="att.global.analytic" mode="delete"/>
+                <memberOf key="att.global.facs" mode="delete"/>
+                <memberOf key="att.global.responsibility" mode="delete"/>
+                <memberOf key="att.global.source" mode="delete"/>
+                <memberOf key="att.typed" mode="add"/>
+            </classes>
+            <!-- text node here is to remove the insane macro.phraseSeq.limited
+            which we really don't need; we want language ident in an attribute
+            and the human-readable name of the language as a child text node 
+            of <language>, not all that baggage -->
+            <content>
+                <alternate minOccurs="0" maxOccurs="unbounded">
+                    <macroRef key="model.languageProfile"/>
+                </alternate>
+            </content>
+            <!--2021-09-21 (TT): add @role so that we can properly document language use in the header-->
+            <attList>
+                <attDef ident="role" mode="add" usage="req">
+                    <valList mode="add" type="closed">
+                        <valItem ident="objectLanguage">
+                            <desc>Object language is the "language being described." (ISO
+                                16642:2017)</desc>
+                        </valItem>
+                        <valItem ident="workingLanguage">
+                            <desc>Working language is the "language used to describe objects." (ISO
+                                16642:2017)</desc>
+                        </valItem>
+                        <valItem ident="sourceLanguage">
+                            <desc>Source language is the language of the content to be translated.
+                                (ISO 17100:215)</desc>
+                        </valItem>
+                        <valItem ident="targetLanguage">
+                            <desc>Target language is the language of the content into which source
+                                language content is translated. (ISO 17100:215)</desc>
+                        </valItem>
+                    </valList>
+                </attDef>
+                <attDef ident="status"/>
+            </attList>
+            <exemplum>
+                <p>When the human-readable name(s) of languages are provided in multiple languages,
+                    the attribute <att>xml:lang</att> should be used on <gi>language</gi></p>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                    <xi:include
+                        href="../TEILex0.examples/headers/LanguageProfileExamples.stripped.xml"
+                        corresp="../TEILex0.examples/headers/LanguageProfileExamples.xml"
+                        xpointer="element(/1/1/2/1)"/>
+                </egXML>
+            </exemplum>
+            <exemplum>
+                <p>Bilingual or multilingual dictionaries could be documented as having two or more
+                    object languages. In those cases, however, it is recommended -- and more precise
+                    -- to describe each object language as either a source language or a target
+                    language.</p>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                    <langUsage>
+                        <language ident="chu" role="sourceLanguage"><name>Old Church Slavic</name></language>
+                        <language ident="la" role="targetLanguage"><name>Latin</name></language>
+                        <language ident="grc" role="targetLanguage"><name>(Premodern)
+                            Greek</name></language>
+                    </langUsage>
+                </egXML>
+            </exemplum>
+            <exemplum>
+                <p>The <att>ident</att> attribute is required and is used to indicate the language
+                    code used for the given lanuguage variety in the rest of the dictionary. If
+                    multiple language identifiers exist for the given language variety, they should
+                    be encoded using the <gi>ident</gi> element.</p>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                    <xi:include
+                        href="../TEILex0.examples/headers/LanguageProfileExamples.stripped.xml"
+                        corresp="../TEILex0.examples/headers/LanguageProfileExamples.xml"
+                        xpointer="element(/1/1/2/2)"/>
+                </egXML>
+            </exemplum>
+            <remarks>
+                <!--Remarks appear as a note before examples.-->
+                <p>In a monolingual dictionary, where the object language and the working language
+                    are the same, one should list each as a separate <gi>language</gi> element with
+                    a specific <att>role</att> attribute. A human-readable, informal prose
+                    characterization should be supplied in the child <gi>name</gi> element. </p>
+            </remarks>
+        </elementSpec>
+        <!-- 2020-06-24 (TT): allowing langUsage and language to document language tags-->
+        <elementSpec ident="langUsage" mode="change">
+            <classes mode="change">
+                <memberOf key="att.global" mode="delete"/>
+                <memberOf key="att.global.rendition" mode="delete"/>
+                <memberOf key="att.global.linking" mode="delete"/>
+                <memberOf key="att.global.analytic" mode="delete"/>
+                <memberOf key="att.global.facs" mode="delete"/>
+                <memberOf key="att.global.responsibility" mode="delete"/>
+                <memberOf key="att.global.source" mode="delete"/>
+                <memberOf key="att.global.change" mode="delete"/>
+                <memberOf key="att.declarable" mode="delete"/>
+            </classes>
+            <!-- 2021-09-23 (TT): make language required-->
+            <content>
+                <sequence>
+                    <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
+                    <elementRef key="language" minOccurs="1" maxOccurs="unbounded"/>
+                </sequence>
+            </content>
+            <exemplum>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                    <langUsage>
+                        <language ident="chu" role="sourceLanguage"><name>Old Church Slavic</name></language>
+                        <language ident="la" role="targetLanguage"><name>Latin</name></language>
+                        <language ident="grc" role="targetLanguage"><name>(Premodern)
+                            Greek</name></language>
+                    </langUsage>
+                </egXML>
+            </exemplum>
+        </elementSpec>
+        <!-- adding lbl to model.sensePart -->
+        <elementSpec ident="lbl" mode="change">
+            <classes mode="change">
+                <memberOf key="model.sensePart" mode="add"/>
+                <!--2019-02-19 (TT): changed from 'delete' (which was in error) to 'add' in model.entryPart.top";
+                                this is temporary because of issue with oxygen and tei-c servers; is already part of TEI-->
+                <memberOf key="model.entryPart.top" mode="add"/>
+                <memberOf key="model.emphLike" mode="add"/>
+            </classes>
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <elementSpec ident="listBibl" mode="change">
+            <!--2025-11-27 (TT): added to to model.languageProfile-->
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+            <attList>
+                <attDef ident="type" mode="change" usage="req">
+                    <valList type="semi" mode="change">
+                        <valItem ident="dictionaries"/>
+                        <valItem ident="corpora"/>
+                        <valItem ident="literature"/>
+                    </valList>
                 </attDef>
             </attList>
+        </elementSpec>
+        <elementSpec ident="measure" mode="change">
+            <classes mode="change">
+                <memberOf key="model.measureLike" mode="delete"/>
+            </classes>
+            <content>
+                <textNode/>
+            </content>
+            <exemplum>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples">
+                    <extent>
+                        <measure unit="pages" quantity="210">210 pp.</measure>
+                    </extent>
+                </egXML>
+            </exemplum>
+            <exemplum versionDate="2025-12-07" xml:lang="en">
+                <p>The <gi>extent</gi> element may be used to supply statistical information about a
+                    given dictionary.</p>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-extent-egXML-si2">
+                    <fileDesc>
+                        <!-- ... -->
+                        <extent>
+                            <measure unit="entries" quantity="15,306"/>
+                            <measure unit="senses" quantity="46,558"/>
+                        </extent>
+                    </fileDesc>
+                </egXML>
+            </exemplum>
+            <remarks>
+                <p>In TEI Lex-0, <gi>measure</gi> is used exclusively within <gi>extent</gi> to
+                    express quantified information about a carrier, such as page counts, dimensions,
+                    file sizes, or measurable lexicographic properties such as the number of
+                    entries, senses, examples etc.</p>
+            </remarks>
+        </elementSpec>
+        <elementSpec ident="name" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <elementSpec ident="note" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!--2020-06-25 (TT): num, to be used strictly for numbering entries and senses -->
+        <elementSpec ident="num" mode="change">
+            <classes mode="replace">
+                <memberOf key="model.entryPart.top"/>
+                <memberOf key="model.sensePart"/>
+            </classes>
+            <!--same as with language above-->
+            <content>
+                <textNode/>
+            </content>
+        </elementSpec>
+        <!--2020-05-14 add orth and pron to att.datable.w3c to allow @notBefore etc.-->
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="orth" mode="change">
+            <classes mode="change">
+                <memberOf key="att.datable.w3c" mode="add"/>
+            </classes>
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <elementSpec ident="person" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <elementSpec ident="personGrp" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!--2021-09-23 (TT): make langUsage required (through model.profileDescPart)-->
+        <elementSpec ident="profileDesc" mode="change">
+            <content>
+                <classRef key="model.profileDescPart" minOccurs="1" maxOccurs="unbounded"/>
+            </content>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="pron" mode="change">
+            <classes mode="change">
+                <memberOf key="att.datable.w3c" mode="add"/>
+            </classes>
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <!--2021-09-20 (TT): make availability required in publicationStmt-->
+        <!--2021-09-21 (TT): make publicationStmtPart.agency unbound so that one can
+            add both authority and publisher; we agreed that authority should be used 
+            for encoding rights holders-->
+        <elementSpec ident="publicationStmt" mode="change">
+            <content>
+                <sequence>
+                    <classRef key="model.publicationStmtPart.agency" minOccurs="1"
+                        maxOccurs="unbounded"/>
+                    <classRef key="model.publicationStmtPart.detail" minOccurs="0"
+                        maxOccurs="unbounded"/>
+                    <elementRef key="availability"/>
+                </sequence>
+            </content>
+        </elementSpec>
+        <elementSpec ident="purpose" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
         </elementSpec>
         <!-- 2018-09-1 (LR): the <ref> element is adapted to have specific @type values (semi-closed) -->
         <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
@@ -247,6 +735,132 @@
                         <!-- further values to be added there -->
                         <!-- 2025-11-27 (TT): added bibliography -->
                         <valItem ident="example"/>
+                    </valList>
+                </attDef>
+            </attList>
+        </elementSpec>
+        <!--2025-11-29 (TT): model.lexicalPhrase is a paired-down model.phrase for dictionaries-->
+        <elementSpec ident="ruby" mode="change">
+            <classes mode="change">
+                <memberOf key="model.lexicalPhrase" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="seg" mode="change">
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <!-- 2018-09-03 (LR): making @xml:id mandatory on sense -->
+        <elementSpec ident="sense" mode="change">
+            <classes mode="change">
+                <memberOf key="model.sensePart" mode="add"/>
+            </classes>
+            <content>
+                <alternate minOccurs="0" maxOccurs="unbounded">
+                    <!-- 2019-06-25 (TT): removed <textNode/> because we don't mixed content in sense-->
+                    <classRef key="model.gLike"/>
+                    <!-- following line useless since sense is member of model.sensePart -->
+                    <!--<elementRef key="sense"/>
+                                -->
+                    <classRef key="model.sensePart"/>
+                    <classRef key="model.lexicalPhrase"/>
+                    <classRef key="model.global"/>
+                </alternate>
+            </content>
+            <attList>
+                <attDef ident="xml:id" mode="change" usage="req"/>
+                <attDef ident="level" mode="delete"/>
+            </attList>
+        </elementSpec>
+        <elementSpec ident="settingDesc" mode="change">
+            <classes mode="change">
+                <memberOf key="model.languageProfile" mode="add"/>
+            </classes>
+        </elementSpec>
+        <!--2021-09-21 (TT): allow only biblStruct in sourceDesc-->
+        <elementSpec ident="sourceDesc" mode="change">
+            <content>
+                <elementRef key="listBibl" minOccurs="1" maxOccurs="unbounded"/>
+            </content>
+            <exemplum>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="sw34hfa">
+                    <sourceDesc>
+                        <biblStruct>
+                            <listBibl type="dictionaries">
+                                <biblStruct>
+                                    <monogr>
+                                        <author>
+                                            <surname>Miklosich</surname>
+                                            <forename>Franz</forename></author>
+                                        <title>Lexicon Palaeoslovenico-Graeco-Latinum</title>
+                                        <imprint>
+                                            <publisher>Guilelmus Braumueller</publisher>
+                                            <pubPlace>Vindobonae</pubPlace>
+                                            <date>1862</date>
+                                        </imprint>
+                                    </monogr>
+                                </biblStruct>
+                            </listBibl>
+                        </biblStruct>
+                    </sourceDesc>
+                </egXML>
+            </exemplum>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="stress" mode="change">
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="syll" mode="change">
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+        </elementSpec>
+        <!--2023-04-20 (TT) make type mandatory on TEI-->
+        <elementSpec ident="TEI" mode="change">
+            <attList>
+                <attDef ident="type" mode="change" usage="req">
+                    <valList mode="add" type="closed">
+                        <valItem ident="lex-0"/>
+                    </valList>
+                </attDef>
+            </attList>
+        </elementSpec>
+        <!--2021-09-24 (TT): make profileDesc required to document use of languages in langUsage-->
+        <elementSpec ident="teiHeader" mode="change">
+            <content>
+                <sequence>
+                    <elementRef key="fileDesc"/>
+                    <elementRef key="encodingDesc" minOccurs="0"/>
+                    <elementRef key="profileDesc" minOccurs="1"/>
+                    <!--<classRef key="model.teiHeaderPart"
+                        minOccurs="0" maxOccurs="unbounded"/>-->
+                    <elementRef key="xenoData" minOccurs="0"/>
+                    <elementRef key="revisionDesc" minOccurs="0"/>
+                </sequence>
+            </content>
+        </elementSpec>
+        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
+        <elementSpec ident="title" mode="change">
+            <content>
+                <macroRef key="macro.lexicalParaContent"/>
+            </content>
+            <attList>
+                <attDef ident="type" mode="replace" usage="rec">
+                    <valList>
+                        <valItem ident="full">
+                            <desc>The full title of a lexicographic resource, such as <egXML 
+                                    xmlns="http://www.tei-c.org/ns/Examples">
+                                    <title type="full">The Oxford English Dictionary</title></egXML>.</desc>
+                        </valItem>
+                        <valItem ident="abbr">
+                            <desc>The preferred abbreviated title of a lexicographic resource, such
+                                as the <egXML xmlns="http://www.tei-c.org/ns/Examples"><title
+                                        type="abbr">OED</title></egXML>.</desc>
+                        </valItem>
                     </valList>
                 </attDef>
             </attList>
@@ -317,823 +931,196 @@
                 </egXML>
             </exemplum>
         </elementSpec>
-        <!-- adding lang to model.entryPart (to make it member of <cit>, if you ask) -->
-        <!-- 2019-10-22 (LR) created ambiguous models... mended -->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        
-        <elementSpec ident="lang" mode="change">
-            <!--<classes mode="change">
-                            <memberOf key="model.entryPart" mode="add"/>
+        <!-- 2018-07-17 (LR): the <xr> element is adapted to have specific @type values -->
+        <!-- implemented default value to lexical -->
+        <!-- introducing @subtype (note to myself: make feature request to TEI so that xr belongs to att.typed -->
+        <!-- made member of att.notated (for having @notation) ==> to be discussed -->
+        <elementSpec ident="xr" mode="change">
+            <classes mode="change">
+                <memberOf key="model.sensePart" mode="add"/>
+                <!-- 2018-12-04 [LR] to have <xr> in <def> and few other cool places -->
+                <!-- 2019-10-22 [LR] deleted to prevent ambiguous content model -->
+                <!--<memberOf key="model.emphLike" mode="add"/>-->
+                <!--<classes mode="change">
+                            <memberOf key="att.notated" mode="add"/>
                         </classes>-->
-            <classes mode="change">
-                <!--because we don't use model.nameLike in model.lexicalPhrase-->
-                 <memberOf key="model.lexicalPhrase" mode="add"/>
-            </classes>
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-            <exemplum>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="d1e5322">
-                    <cit type="cognate">
-                        <lang>dän.</lang>
-                        <form>
-                            <orth xml:lang="da">indgang</orth>
-                        </form>
-                    </cit>
-                </egXML>
-            </exemplum>
-            <exemplum>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="d1e5340">
-                    <cit type="etymon">
-                        <lang>mhd.</lang>
-                        <form type="variant">
-                            <orth xml:lang="gmh">vreten</orth>
-                        </form>
-                        <form type="variant">
-                            <orth xml:lang="gmh">vretten</orth>
-                        </form>
-                        <form type="variant">
-                            <orth xml:lang="gmh">vraten</orth>
-                        </form>
-                        <gloss>entzünden</gloss><pc>;</pc> <gloss>wundreiben</gloss><pc>;</pc> <gloss>herumziehen</gloss><pc>;</pc> <gloss>quälen</gloss><pc>;</pc> <gloss>plagen</gloss>
-                    </cit>
-                </egXML>
-            </exemplum>
-        </elementSpec>
-        <!-- adding def to model.sensePart -->
-        <!--2020-06-30 (TT): def is only allowed within a sense!-->
-        <!--TODO: at the moment, it's still allowed in etym, but it shouldn't be
-        because if there is no sense, we have to use gloss. fix later-->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="def" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-                <memberOf key="model.entryPart.top" mode="delete"/>
-                <memberOf key="model.entryPart" mode="delete"/>
-            </classes>
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!-- adding cit to model.sensePart -->
-        <elementSpec ident="cit" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-            </classes>
-            <content>
-                <alternate minOccurs="1" maxOccurs="unbounded">
-                    <classRef key="model.quoteLike"/>
-                    <classRef key="model.egLike"/>
-                    <classRef key="model.biblLike"/>
-                    <classRef key="model.ptrLike"/>
-                    <classRef key="model.global"/>
-                    <classRef key="model.entryPart"/>
-                    <!-- 2019-06-25 (TT): adding  model.segLike to allow pc etc. in cit -->
-                    <classRef key="model.segLike"/>
-                    <!-- 2019-10-22 (LR): adding <lang> to deal with etymological descriptions -->
-                    <elementRef key="lang"/>
-                    <!-- 2019-11-20 (LR): adding <gloss> to deal with etymological descriptions -->
-                    <elementRef key="gloss"/>
-                </alternate>
-            </content>
-            <attList>
-                <attDef ident="type" mode="replace" usage="req">
-                    <valList type="closed" mode="change">
-                        <valItem ident="example"/>
-                        <valItem ident="translation"/>
-                        <valItem ident="translationEquivalent"/>
-                        <valItem ident="etymon"/>
-                        <valItem ident="cognate"/>
-                        <valItem ident="cognateSet"/>
-                    </valList>
-                </attDef>
-            </attList>
-        </elementSpec>
-        <!-- adding form to model.sensePart -->
-        <elementSpec ident="form" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-            </classes>
-            <content>
-                <alternate minOccurs="0"
-                    maxOccurs="unbounded">
-                    <textNode/>
-                    <classRef key="model.gLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.formPart"/>
-                    <classRef key="model.global"/>
-                </alternate>
-            </content>
-        </elementSpec>
-        <!-- adding gramGrp to model.sensePart -->
-        <elementSpec ident="gramGrp" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-            </classes>
-            <content>
-                <alternate minOccurs="0"
-                    maxOccurs="unbounded">
-                    <textNode/>
-                    <classRef key="model.gLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.gramPart"/>
-                    <classRef key="model.global"/>
-                </alternate>
-            </content>
-        </elementSpec>
-        <!-- adding etym to model.sensePart -->
-        <elementSpec ident="etym" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
+                <!--2020-05-14 allow inside quote (for cross-references in examples)-->
+                <memberOf key="model.quoteLike" mode="add"/>
             </classes>
             <content>
                 <alternate minOccurs="0" maxOccurs="unbounded">
-                    <textNode/>
                     <classRef key="model.gLike"/>
-                    <classRef key="model.global"/>
-                    <classRef key="model.lexicalInter"/>
                     <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.descLike"/>
-                    <elementRef key="def"/>
-                    <elementRef key="etym"/>
-                    <elementRef key="gramGrp"/>
-                    <elementRef key="lbl"/>
+                    <classRef key="model.lexicalInter"/>
                     <elementRef key="usg"/>
-                    <elementRef key="xr"/>
+                    <elementRef key="lbl"/>
+                    <classRef key="model.global"/>
                 </alternate>
-            </content>
-            <attList>
-                <attDef ident="type" mode="replace" usage="rec">
-                    <valList type="closed" mode="change">
-                        <valItem ident="borrowing"/>
-                        <valItem ident="inheritance"/>
-                        <valItem ident="metaphor"/>
-                        <valItem ident="metonymy"/>
-                        <valItem ident="compounding"/>
-                        <valItem ident="grammaticalization"/>
-                        <valItem ident="derivation"/>
-                    </valList>
-                </attDef>
-            </attList>
-        </elementSpec>
-        <!-- adding lbl to model.sensePart -->
-        <elementSpec ident="lbl" mode="change">
-            <classes mode="change">
-                <memberOf key="model.sensePart" mode="add"/>
-                <!--2019-02-19 (TT): changed from 'delete' (which was in error) to 'add' in model.entryPart.top";
-                                this is temporary because of issue with oxygen and tei-c servers; is already part of TEI-->
-                <memberOf key="model.entryPart.top" mode="add"/>
-                <memberOf key="model.emphLike" mode="add"/>
-            </classes>
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!--2020-05-14 add orth and pron to att.datable.w3c to allow @notBefore etc.-->
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="orth" mode="change">
-            <classes mode="change">
-                <memberOf key="att.datable.w3c" mode="add"/>
-            </classes>
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="hyph" mode="change">
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="pron" mode="change">
-            <classes mode="change">
-                <memberOf key="att.datable.w3c" mode="add"/>
-            </classes>
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="stress" mode="change">
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="syll" mode="change">
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!-- 2020-06-24 (TT): allowing langUsage and language to document language tags-->
-        <elementRef key="langUsage"/>
-        <elementSpec ident="langUsage" mode="change">
-            <classes mode="change">
-                <memberOf key="att.global" mode="delete"/>
-                <memberOf key="att.global.rendition" mode="delete"/>
-                <memberOf key="att.global.linking" mode="delete"/>
-                <memberOf key="att.global.analytic" mode="delete"/>
-                <memberOf key="att.global.facs" mode="delete"/>
-                <memberOf key="att.global.responsibility" mode="delete"/>
-                <memberOf key="att.global.source" mode="delete"/>
-                <memberOf key="att.global.change" mode="delete"/>
-                <memberOf key="att.declarable" mode="delete"/>
-            </classes>
-            <!-- 2021-09-23 (TT): make language required-->
-            <content>
-                <sequence>
-                    <classRef key="model.pLike" minOccurs="0" maxOccurs="unbounded"/>
-                    <elementRef key="language" minOccurs="1" maxOccurs="unbounded"/>
-                </sequence>
-            </content>
-            <exemplum>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                    <langUsage>
-                        <language ident="chu" role="sourceLanguage"><name>Old Church Slavic</name></language>
-                        <language ident="la" role="targetLanguage"><name>Latin</name></language>
-                        <language ident="grc" role="targetLanguage"><name>(Premodern) Greek</name></language>
-                </langUsage>
-                </egXML>
-            </exemplum>
-        </elementSpec>
-        <!--2021-09-23 (TT): make langUsage required (through model.profileDescPart)-->
-        <elementSpec ident="profileDesc" mode="change">
-            <content>
-                <classRef key="model.profileDescPart" minOccurs="1" maxOccurs="unbounded"/>
-            </content>
-        </elementSpec>
-        <elementSpec ident="language" mode="change">
-            <classes mode="replace">
-                <memberOf key="att.global.rendition" mode="delete"/>
-                <memberOf key="att.global.linking" mode="delete"/>
-                <memberOf key="att.global.analytic" mode="delete"/>
-                <memberOf key="att.global.facs" mode="delete"/>
-                <memberOf key="att.global.responsibility" mode="delete"/>
-                <memberOf key="att.global.source" mode="delete"/>
-                <memberOf key="att.typed" mode="add"></memberOf>
-            </classes>
-            <!-- text node here is to remove the insane macro.phraseSeq.limited
-            which we really don't need; we want language ident in an attribute
-            and the human-readable name of the language as a child text node 
-            of <language>, not all that baggage -->
-            <content>
-                <alternate minOccurs="0"
-                    maxOccurs="unbounded">
-                    <macroRef key="model.languageProfile"  />
-                </alternate>
-            </content>
-            
-            <!--2021-09-21 (TT): add @role so that we can properly document language use in the header-->
-            <attList>
-                <attDef ident="role" mode="add" usage="req">
-                    
-                    <valList mode="add" type="closed">
-                        <valItem ident="objectLanguage">
-                            <desc>Object language is the "language being described." (ISO
-                                16642:2017)</desc>
-                        </valItem>
-                        <valItem ident="workingLanguage">
-                            <desc>Working language is the "language used to describe objects." (ISO
-                                16642:2017)</desc>
-                        </valItem>
-                        <valItem ident="sourceLanguage">
-                            <desc>Source language is the language of the content to be translated.
-                                (ISO 17100:215)</desc>
-                        </valItem>
-                        <valItem ident="targetLanguage">
-                            <desc>Target language is the language of the content into which source
-                                language content is translated. (ISO 17100:215)</desc>
-                        </valItem>
-                    </valList>
-                </attDef>
-                <attDef ident="status"></attDef>
-            </attList>
-            <exemplum>
-                <p>When the human-readable name(s) of languages are provided in multiple languages, the
-                    attribute <att>xml:lang</att> should be used on <gi>language</gi></p>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                   <xi:include href="../TEILex0.examples/headers/LanguageProfileExamples.stripped.xml"
-                        corresp="../TEILex0.examples/headers/LanguageProfileExamples.xml"
-                        xpointer="element(/1/1/2/1)"/>
-                </egXML>
-            </exemplum>
-            <exemplum>
-                <p>Bilingual or multilingual dictionaries could be documented as having two or more object languages. In
-                    those cases, however, it is recommended -- and more precise -- to describe each
-                    object language as either a source language or a target language.</p>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples">  
-                    <langUsage>
-                        <language ident="chu" role="sourceLanguage"><name>Old Church Slavic</name></language>
-                        <language ident="la" role="targetLanguage"><name>Latin</name></language>
-                        <language ident="grc" role="targetLanguage"><name>(Premodern) Greek</name></language>
-                    </langUsage>   
-                </egXML>
-            </exemplum>
-            <exemplum>
-                <p>The <att>ident</att> attribute is required and is used to indicate the language code used for the given lanuguage
-                variety in the rest of the dictionary. If multiple language identifiers exist for the given language variety, they should
-                be encoded using the <gi>ident</gi> element.</p>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                    <xi:include href="../TEILex0.examples/headers/LanguageProfileExamples.stripped.xml"
-                        corresp="../TEILex0.examples/headers/LanguageProfileExamples.xml"
-                        xpointer="element(/1/1/2/2)"/>
-                </egXML>
-            </exemplum>
-            <remarks>
-                <!--Remarks appear as a note before examples.-->
-                <p>In a monolingual dictionary, where the object language and the working language
-                    are the same, one should list each as a separate <gi>language</gi> element with
-                    a specific <att>role</att> attribute. A human-readable, informal prose
-                    characterization should be supplied in the child <gi>name</gi> element. </p>
-                
-            </remarks>
-        </elementSpec>
-        <elementSpec ident="name" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="date" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="person" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="personGrp" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="channel" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="ident" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="interaction" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="domain" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="purpose" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="desc" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="note" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <elementSpec ident="settingDesc" mode="change">
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        
-        <!--2021-09-24 (TT): make profileDesc required to document use of languages in langUsage-->
-        <elementSpec ident="teiHeader" mode="change">
-            <content>
-                <sequence>
-                    <elementRef key="fileDesc"/>
-                    <elementRef key="encodingDesc" minOccurs="0"/>
-                    <elementRef key="profileDesc" minOccurs="1"/>
-                    <!--<classRef key="model.teiHeaderPart"
-                        minOccurs="0" maxOccurs="unbounded"/>-->
-                    <elementRef key="xenoData" minOccurs="0"/>
-                    <elementRef key="revisionDesc" minOccurs="0"/>
-                </sequence>
-            </content>
-        </elementSpec>
-        <!--2023-04-20 (TT) make type mandatory on TEI-->
-        <elementSpec ident="TEI" mode="change">
-            <attList>
-                <attDef ident="type" mode="change" usage="req">
-                    <valList mode="add" type="closed">
-                        <valItem ident="lex-0"></valItem>
-                    </valList>
-                </attDef>
-            </attList>
-        </elementSpec>
-        
-        <!-- 2021-09-26 (TT): dont't require sourceDesc in fileDesc; we want it 
-        only if we can provide a proper biblStruct for it; otherwise, it's useless
-        (i.e. we don't want <sourceDesc><p>Born digital</p></sourceDesc> -->
-        <elementSpec ident="fileDesc" mode="change">
-            <content>
-                <sequence>
-                    <sequence>
-                        <elementRef key="titleStmt"/>
-                        <elementRef key="editionStmt" minOccurs="0"/>
-                        <elementRef key="extent" minOccurs="0"/>
-                        <elementRef key="publicationStmt"/>
-                        <elementRef key="seriesStmt" minOccurs="0" maxOccurs="unbounded"/>
-                        <elementRef key="notesStmt" minOccurs="0"/>
-                    </sequence>
-                    <elementRef key="sourceDesc" minOccurs="0" maxOccurs="unbounded"/>
-                </sequence>
-            </content>
-        </elementSpec>
-        <!--2020-06-25 (TT): num, to be used strictly for numbering entries and senses -->
-        <elementSpec ident="num" mode="change">
-            <classes mode="replace">
-                <memberOf key="model.entryPart.top"/>
-                <memberOf key="model.sensePart"/>
-            </classes>
-            <!--same as with language above-->
-            <content>
-                <textNode/>
-            </content>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="gram" mode="change">
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
             </content>
             <attList>
                 <attDef ident="type" mode="replace" usage="req">
-                    <valList type="semi" mode="change">
-                        <valItem ident="pos">
-                            <equiv name="pos"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-pos.html"
-                            />
+                    <defaultVal>related</defaultVal>
+                    <valList type="closed" mode="change">
+                        <!-- 2018-12-06-->
+                        <!--<valItem ident="crossReference"/>-->
+                        <valItem ident="synonymy">
+                            <desc>Relation between two lexical units X and Y which are syntactically
+                                identical and have the property that any declarative sentence S
+                                containing X has equivalent truth conditions to another sentence S’
+                                which is identical to S, except that X is replaced by Y. (Adapted
+                                from Cruse (1986).)</desc>
+                            <remarks>
+                                <p>Synonymy is the linguistic parallel of the identity relation
+                                    between classes. Synonyms differ in peripheral traits, related
+                                    for example to stylistic, dialectal or diachronic
+                                    variations.</p>
+                                <p>Examples: [de] {Hund, Köter}, [en] {flashlight, torch}, [en]
+                                    {glad, joyful, happy}, [en] {violin, fiddle} [en] He plays the
+                                    violin very well/He plays the fiddle very well.</p>
+                            </remarks>
                         </valItem>
-                        <valItem ident="aspect"/>
-                        <valItem ident="case">
-                            <equiv name="case"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-case.html"
-                            />
+                        <valItem ident="hyponymy">
+                            <desc> Relation between lexical units X and Y characterised by the
+                                property that the sentence ‘This is a(n) X’ entails, but is not
+                                entailed by the sentence ‘This is a(n) Y’. (Adapted from Cruse
+                                (1986).) </desc>
+                            <remarks>
+                                <p>Hyponymy and its converse hypernymy are the linguistic parallels
+                                    of the relation of inclusion between two classes.</p>
+                                <p>Examples: [en] animal/dog, red/scarlet, to kill/to murder</p>
+                                <p>[en] This is a dog. => This is an animal.</p>
+                                <p>[en] This is a scarlet flower. => This is a red flower.</p>
+                            </remarks>
                         </valItem>
-                        <valItem ident="construction"/>
-                        <valItem ident="degree"/>
-                        <valItem ident="gender">
-                            <equiv name="gen"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-gen.html"
-                            />
+                        <valItem ident="hypernymy">
+                            <desc>Relation between lexical heads X and Y characterised by the
+                                property that the sentence ‘This is a(n) Y’ entails, but is not
+                                entailed by the sentence ‘This is a(n) X’. (Adapted from Cruse
+                                (1986).) </desc>
+                            <remarks>
+                                <p>Hypernymy is the converse of hyponymy.</p>
+                                <p> Example: dog/animal (animal is a hypernym of dog)</p>
+                            </remarks>
                         </valItem>
-                        <valItem ident="inflectionType">
-                            <equiv name="iType"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-iType.html"
-                            />
+                        <valItem ident="meronymy">
+                            <desc>An inclusion relation between lexical heads X and Y which reflect
+                                a potential part-whole relation between their referents in
+                                discourse. (Adapted from Cruse (2011, p. 140).)</desc>
+                            <remarks>
+                                <p>Example: finger:hand (finger is said to be a meronym of hand, and
+                                    hand is said to be the holonym of finger).</p>
+                            </remarks>
                         </valItem>
-                        <valItem ident="mood">
-                            <equiv name="mood"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-mood.html"
-                            />
+                        <valItem ident="antonymy"/>
+                        <valItem ident="related">
+                            <desc>The default reference to another lexical unit when no additional
+                                information is available.</desc>
                         </valItem>
-                        <valItem ident="number">
-                            <equiv name="number"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-number.html"
-                            />
-                        </valItem>
-                        <valItem ident="tense">
-                            <equiv name="tns"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-tns.html"
-                            />
-                        </valItem>
-                        <valItem ident="valency"/>
-                        <valItem ident="collocate">
-                            <equiv name="colloc"
-                                uri="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-colloc.html"
-                            />
-                        </valItem>
+                        <!-- further values to be added there -->
                     </valList>
                 </attDef>
-            </attList>
-            
-        </elementSpec>
-        <!--2021-09-20 (TT): make availability required in publicationStmt-->
-        <!--2021-09-21 (TT): make publicationStmtPart.agency unbound so that one can
-            add both authority and publisher; we agreed that authority should be used 
-            for encoding rights holders-->
-        <elementSpec ident="publicationStmt" mode="change">
-            <content>
-                <sequence>
-                    <classRef key="model.publicationStmtPart.agency" minOccurs="1"
-                        maxOccurs="unbounded"/>
-                    <classRef key="model.publicationStmtPart.detail" minOccurs="0"
-                        maxOccurs="unbounded"/>
-                    <elementRef key="availability"/>
-                </sequence>
-            </content>
-        </elementSpec>
-        <!--2021-09-21 (TT): add @role to authority so that we can specify
-        what kind of authority we're talking about; for instance 
-        <authority role="rightsHolder"></authority>-->
-        <elementSpec ident="authority" mode="change">
-            <attList>
-                <attDef ident="role" mode="add">
-                    <valList mode="add" type="semi">
-                        <valItem ident="funder"/>
-                        <valItem ident="sponsor"/>
-                        <valItem ident="rightsHolder"/>
-                    </valList>
-                </attDef>
-            </attList>
-        </elementSpec>
-        <!--2021-09-21 (TT): allow only biblStruct in sourceDesc-->
-        <elementSpec ident="sourceDesc" mode="change">
-            <content>
-                <elementRef key="listBibl" minOccurs="1" maxOccurs="unbounded"/>
-            </content> 
-            <exemplum>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="sw34hfa">
-                    <sourceDesc>
-                        <biblStruct>
-                            <listBibl type="dictionaries">
-                                <biblStruct>
-                                    <monogr>
-                                        <author>
-                                            <surname>Miklosich</surname>
-                                            <forename>Franz</forename></author>
-                                        <title>Lexicon Palaeoslovenico-Graeco-Latinum</title>
-                                        <imprint>
-                                            <publisher>Guilelmus Braumueller</publisher>
-                                            <pubPlace>Vindobonae</pubPlace>
-                                            <date>1862</date>
-                                        </imprint>
-                                    </monogr>
-                                </biblStruct>
-                            </listBibl>
-                        </biblStruct>
-                    </sourceDesc>
-                </egXML>
-            </exemplum>
-        </elementSpec>
-        <elementSpec ident="bibl" mode="change">
-            <!--2025-11-27 (TT): added to to model.languageProfile-->
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-        </elementSpec>
-        <elementSpec ident="listBibl" mode="change">
-            <!--2025-11-27 (TT): added to to model.languageProfile-->
-            <classes mode="change">
-                <memberOf key="model.languageProfile" mode="add"/>
-            </classes>
-            <attList>
-                <attDef ident="type" mode="change" usage="req">
-                    <valList type="semi" mode="change">
-                        <valItem ident="dictionaries"></valItem>
-                        <valItem ident="corpora"></valItem>
-                        <valItem ident="literature"></valItem>
-                    </valList>
-                </attDef>
-            </attList>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="seg" mode="change">
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-        </elementSpec>
-        <!--2023-01-23 (TT): change content model to macro.lexicalParaContent-->
-        <elementSpec ident="title" mode="change">
-            <content>
-                <macroRef key="macro.lexicalParaContent"/>
-            </content>
-            <attList>
-                <attDef ident="type" mode="replace" usage="rec">
-                    <valList>
-                        <valItem ident="full">
-                            <desc>The full title of a lexicographic resource, such as
-                                <egXML xmlns="http://www.tei-c.org/ns/Examples"><title type="full">The Oxford English Dictionary</title></egXML>.</desc>
-                        </valItem>
-                        <valItem ident="abbr">
-                            <desc>The preferred abbreviated title of a lexicographic resource, such
-                                as the
-                                <egXML xmlns="http://www.tei-c.org/ns/Examples"><title type="abbr">OED</title></egXML>.</desc>
-                        </valItem>
-                    </valList>
+                <attDef ident="subtype" mode="replace" usage="opt">
+                    <datatype>
+                        <dataRef key="teidata.enumerated"/>
+                    </datatype>
                 </attDef>
             </attList>
         </elementSpec>
         
-        <elementSpec ident="dictScrap" mode="change">
-            <content>
-                <alternate minOccurs="0"
-                    maxOccurs="unbounded">
-                    <textNode/>
-                    <classRef key="model.gLike"/>
-                    <classRef key="model.entryPart"/>
-                    <classRef key="model.morphLike"/>
-                    <classRef key="model.lexicalPhrase"/>
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.global"/>
-                </alternate>
-            </content>
-        </elementSpec>
-        <!--2025-11-29 (TT): model.lexicalPhrase is a paired-down model.phrase for dictionaries-->
-        <elementSpec ident="ruby" mode="change">
+        <!-- ========================================================= -->
+        <!-- SECTION: CLASSES                                          -->
+        <!-- ========================================================= -->
+
+        <classSpec ident="model.attributable" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase" mode="add"/>
+                <memberOf key="model.lexicalInter"/>
             </classes>
-        </elementSpec>
-        
-        <elementSpec ident="extent" mode="change">
-            <content>
-                <elementRef key="measure" minOccurs="1" maxOccurs="unbounded"/>
-            </content>
-            <exemplum versionDate="2016-11-04" xml:lang="en">
-                <p>The  <gi>extent</gi> element may be used to supply normalized
-                    or machine tractable versions of the size or sizes concerned.</p>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-extent-egXML-ig">
-                    <extent>
-                        <measure unit="MiB" quantity="4.2">About four megabytes</measure>
-                        <measure unit="pages" quantity="245">245 pages of source
-                            material</measure>
-                    </extent>
-                </egXML>
-            </exemplum>
-            <exemplum versionDate="2025-12-07" xml:lang="en">
-                <p>The  <gi>extent</gi> element may be used to supply statistical information
-                about a given dictionary.</p>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-extent-egXML-si">
-                    <fileDesc>
-                        <!-- ... -->
-                        <extent>
-                            <measure unit="entries" quantity="15,306"/>
-                            <measure unit="senses" quantity="46,558"/>
-                        </extent>
-                    </fileDesc>
-                </egXML>
-            </exemplum>
-        </elementSpec>
-        <elementSpec ident="measure" mode="change">
-            <classes mode="change">
-                <memberOf key="model.measureLike" mode="delete"></memberOf>
-            </classes>
-            <content>
-                <textNode/>
-            </content>
-            <exemplum>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples">
-                    <extent>
-                        <measure unit="pages" quantity="210">210 pp.</measure>
-                    </extent>
-                </egXML>
-            </exemplum>
-            <exemplum versionDate="2025-12-07" xml:lang="en">
-                <p>The  <gi>extent</gi> element may be used to supply statistical information
-                    about a given dictionary.</p>
-                <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-extent-egXML-si2">
-                    <fileDesc>
-                        <!-- ... -->
-                        <extent>
-                            <measure unit="entries" quantity="15,306"/>
-                            <measure unit="senses" quantity="46,558"/>
-                        </extent>
-                    </fileDesc>  
-                </egXML>
-            </exemplum>
-            <remarks>
-                <p>In TEI Lex-0, <gi>measure</gi> is used exclusively within <gi>extent</gi> to express quantified information about a carrier, such as page counts, dimensions, file sizes, or measurable lexicographic properties such as the number of entries, senses, examples etc.</p>
-            </remarks>
-        </elementSpec>
-        
-        <!-- Class related declaration here -->
-        <!-- Introducing new class for the content model of <sense> -->
-        <!-- Elements remaining to be put in: dictScrap     re -->
-        <!-- and we add: sense to simplify the content model <= but do we want that?!?-->
-        <classSpec type="model" ident="model.sensePart">
-            <desc>groups together all the elements from the dictionary modules that can appear as
-                child of <gi>sense</gi></desc>
         </classSpec>
+
         <!-- Making model.biblLike member of model.entryPart.top so that <bibl> is available in <entry> -->
-        <classSpec type="model" ident="model.biblLike" mode="change">
+        <classSpec ident="model.biblLike" type="model" mode="change">
             <classes mode="change">
                 <memberOf key="model.entryPart.top" mode="add"/>
             </classes>
         </classSpec>
-        <!--2023-01-24 (TT): create model.lexicalInter to simplify content models of certain
-        dictionary elements -->
-        <classSpec type="model" ident="model.lexicalInter" mode="add">
-            <desc> pared-down version of model.inter for use in dictionary elements </desc>
-        </classSpec>
-        
-        <classSpec type="model" ident="model.attributable" mode="change">
+
+        <classSpec ident="model.biblLike" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalInter"></memberOf>
+                <memberOf key="model.lexicalInter"/>
             </classes>
         </classSpec>
-        
-        <classSpec type="model" ident="model.biblLike" mode="change">
+
+        <classSpec ident="model.graphicLike" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalInter"></memberOf>
+                <memberOf key="model.lexicalPhrase"/>
             </classes>
         </classSpec>
-        
+
+        <classSpec ident="model.highlighted" type="model" mode="change">
+            <classes mode="change">
+                <memberOf key="model.lexicalPhrase"/>
+            </classes>
+        </classSpec>
+
+        <classSpec ident="model.hiLike" type="model" mode="change">
+            <classes mode="change">
+                <memberOf key="model.lexicalPhrase"/>
+            </classes>
+        </classSpec>
+
         <!-- 2023-11-27 (TT) model.languageProfile-->
         <classSpec ident="model.languageProfile" type="model">
-            <desc>
-                Groups all elements used to describe a language or language variety:
-                identifiers, names, space/time metadata, social and personal
-                characteristics, medium, and communicative functioning, following
-                ISO 21636.
-            </desc>   
+            <desc> Groups all elements used to describe a language or language variety: identifiers,
+                names, space/time metadata, social and personal characteristics, medium, and
+                communicative functioning, following ISO 21636. </desc>
         </classSpec>
-        
-       <!-- 2023-04-22 (TT) model.lexicalPhrase-->
-        
-        <classSpec type="model" ident="model.lexicalPhrase" mode="add">
+
+        <!--2023-01-24 (TT): create model.lexicalInter to simplify content models of certain
+        dictionary elements -->
+        <classSpec ident="model.lexicalInter" type="model" mode="add">
+            <desc> pared-down version of model.inter for use in dictionary elements </desc>
+        </classSpec>
+
+        <!-- 2023-04-22 (TT) -->
+        <classSpec ident="model.lexicalPhrase" type="model" mode="add">
             <desc> pared-down version of model.phrase for use in dictionary elements </desc>
         </classSpec>
-        
-        <classSpec type="model" ident="model.graphicLike" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalPhrase"></memberOf>
-            </classes>
-        </classSpec>
-        
-        <classSpec type="model" ident="model.highlighted" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalPhrase"></memberOf>
-            </classes>
-        </classSpec>
-        <classSpec type="model" ident="model.hiLike" mode="change">
-            <classes mode="change">
-                <memberOf key="model.lexicalPhrase"></memberOf>
-            </classes>
-        </classSpec>
-        
-      <!--  we're not linlcuding model.nameLike because then we get a bunch
+
+        <!--  we're not linlcuding model.nameLike because then we get a bunch
         of name,orgName,persName,placeName elements etc. inside form,
         orth etc. We do need lang, which is also a member of model.nameLike. 
         We're solving this by making lang a member of model.lexicalPhrase directly-->
-       
         <!--<classSpec type="model" ident="model.nameLike" mode="change">
             <classes mode="change">
                 <memberOf key="model.lexicalPhrase"></memberOf>
             </classes>
         </classSpec>-->
-        
+
         <!--we are not including model.pPart.edit [model.pPart.editorial 
         [abbr am choice ex expan subst] because we don't want to
         introduce abbr, am etc. in a bunch of lexicographic elements, 
         but when we decide to include choice, we'll have to add it 
         on its own here -->
-        
-        <classSpec type="model" ident="model.ptrLike" mode="change">
+        <classSpec ident="model.ptrLike" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase"></memberOf>
+                <memberOf key="model.lexicalPhrase"/>
             </classes>
         </classSpec>
-        <classSpec type="model" ident="model.segLike" mode="change">
+
+        <classSpec ident="model.segLike" type="model" mode="change">
             <classes mode="change">
-                <memberOf key="model.lexicalPhrase"></memberOf>
+                <memberOf key="model.lexicalPhrase"/>
             </classes>
-        </classSpec> 
-        
-        <!-- 2023-04-22 (TT) end of model.lexicalPhrase-->
-        
-        <macroSpec ident="macro.paraLexcialContent">
-            <content rend="replace">
-                <alternate minOccurs="0"
-                    maxOccurs="unbounded">
-                    <textNode/>
-                    <classRef key="model.gLike"/>
-                    <classRef key="model.phrase"/>
-                    <!--<classRef key="model.inter"/>-->
-                    <classRef key="model.lexicalInter"/>
-                    <classRef key="model.global"/>
-                    <elementRef key="lg"/>
-                    <classRef key="model.lLike"/>
-                    <elementRef key="xr"/>
-                </alternate>
-            </content>
-        </macroSpec>
+        </classSpec>
+
+        <classSpec ident="model.sensePart" type="model">
+            <desc>groups together all the elements from the dictionary modules that can appear as
+                child of <gi>sense</gi></desc>
+        </classSpec>
+  
+        <!-- ========================================================= -->
+        <!-- SECTION: ATTRIBUTES                                       -->
+        <!-- ========================================================= -->
         
         <!--2018-09-02 (TT): Added PB's useful class modifications-->
         <!-- three of the TEI attribute classes are simplified. The attributes xml:space,
@@ -1145,7 +1132,7 @@
                         <att>n</att>, <att>xml:lang</att>, <att>xml:base</att>. The attribute class <ident>att.declaring</ident> is
                         deleted completely, so that none of its members inherit the <att>decls</att> attribute
                         defined in the unmodified TEI.-->
-        <classSpec ident="att.global" mode="change" type="atts">
+        <classSpec ident="att.global" type="atts" mode="change">
             <attList>
                 <attDef ident="xml:space" mode="delete"/>
             </attList>
@@ -1157,7 +1144,7 @@
                         </attList>
                     </classSpec>
                     -->
-        <classSpec ident="att.declaring" mode="delete" type="atts"/>
+        <classSpec ident="att.declaring" type="atts" mode="delete"/>
         <classSpec ident="att.fragmentable" type="atts" mode="change">
             <exemplum>
                 <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -1175,7 +1162,8 @@
                                 <def>'hin- und herlaufen'</def>
                             </sense>
                         </cit>
-                        <seg type="desc" part="F">zurückgeführt</seg>; <seg type="desc" part="I">evtl. auch auf </seg>
+                        <seg type="desc" part="F">zurückgeführt</seg>; <seg type="desc" part="I"
+                            >evtl. auch auf </seg>
                         <cit type="etymon">
                             <lang>fnhd.</lang>
                             <form>
@@ -1192,9 +1180,9 @@
                 </egXML>
             </exemplum>
         </classSpec>
-        <classSpec ident="att.divLike" mode="delete" type="atts"/>
+        <classSpec ident="att.divLike" type="atts" mode="delete"/>
         <!--2020-06-26 (TT): att.scoped-->
-        <classSpec type="atts" ident="att.scoped">
+        <classSpec ident="att.scoped" type="atts">
             <attList>
                 <attDef ident="scope">
                     <desc>TEI Lex-0 specific class for providing elements with an attribute
@@ -1206,6 +1194,11 @@
                 </attDef>
             </attList>
         </classSpec>
+        
+        <!-- ========================================================= -->
+        <!-- SECTION: MACROS                                           -->
+        <!-- ========================================================= -->
+        
         <!-- 2019-10-22 (LR) new hack to have <xr> in <def> and similar places -->
         <!-- 2023-01-24 (TT) retired this customization because now we have macro.lexicalParaContent -->
         <!--<macroSpec ident="macro.paraContent" mode="change">

--- a/Schemas/TEILex0/out/TEILex0.xsd
+++ b/Schemas/TEILex0/out/TEILex0.xsd
@@ -1,0 +1,9642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tei="http://www.tei-c.org/ns/1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.tei-c.org/ns/1.0">
+   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="xml.tmp"/>
+   <!--
+    Schema generated from ODD source 2025-12-16T10:41:10Z. . 
+    TEI Edition: P5 Version 4.10.2. Last updated on 4th September 2025, revision bcfa98f42 
+    TEI Edition Location: https://www.tei-c.org/Vault/P5/4.10.2/ 
+    
+  -->
+   <!---->
+   <xs:complexType name="macro.paraContent" mixed="true">
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.paraPart"/>
+   </xs:complexType>
+   <xs:complexType name="macro.limitedContent" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:group ref="tei:model.limitedPhrase"/>
+         <xs:group ref="tei:model.inter"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="macro.phraseSeq" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="tei:model.gLike"/>
+         <xs:group ref="tei:model.attributable"/>
+         <xs:group ref="tei:model.phrase"/>
+         <xs:group ref="tei:model.global"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="macro.phraseSeq.limited" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:group ref="tei:model.limitedPhrase"/>
+         <xs:group ref="tei:model.global"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="macro.specialPara" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="tei:model.gLike"/>
+         <xs:group ref="tei:model.phrase"/>
+         <xs:group ref="tei:model.inter"/>
+         <xs:group ref="tei:model.divPart"/>
+         <xs:group ref="tei:model.global"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="macro.xtext" mixed="true">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:model.gLike"/>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="macro.lexParaContent" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="tei:model.gLike"/>
+         <xs:group ref="tei:model.lexPhrase"/>
+         <xs:group ref="tei:model.global"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="macro.lexSpecialPara" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="tei:model.gLike"/>
+         <xs:group ref="tei:model.hiLike"/>
+         <xs:group ref="tei:model.ptrLike"/>
+         <xs:group ref="tei:model.segLike"/>
+         <xs:element ref="tei:gloss"/>
+         <xs:element ref="tei:ruby"/>
+         <xs:element ref="tei:xr"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:group name="anyElement_xenoData_1">
+      <xs:choice>
+         <xs:any namespace="##other" processContents="skip"/>
+         <xs:any namespace="##local" processContents="skip"/>
+      </xs:choice>
+   </xs:group>
+   <xs:attributeGroup name="att.anchoring.attributes">
+      <xs:attributeGroup ref="tei:att.anchoring.attribute.anchored"/>
+      <xs:attributeGroup ref="tei:att.anchoring.attribute.targetEnd"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.anchoring.attribute.anchored">
+      <xs:attribute name="anchored" default="true" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>(anchored) indicates whether the copy text shows the exact place of reference for the note.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.anchoring.attribute.targetEnd">
+      <xs:attribute name="targetEnd">
+         <xs:annotation>
+            <xs:documentation>(target end) points to the end of the span to which the note is attached, if the note is not embedded in the text at that point.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ascribed.attributes">
+      <xs:attributeGroup ref="tei:att.ascribed.attribute.who"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ascribed.attribute.who">
+      <xs:attribute name="who">
+         <xs:annotation>
+            <xs:documentation>indicates the person, or group of people, to whom the element content is ascribed.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.cReferencing.attributes">
+      <xs:attributeGroup ref="tei:att.cReferencing.attribute.cRef"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.cReferencing.attribute.cRef">
+      <xs:attribute name="cRef" type="xs:string"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.canonical.attributes">
+      <xs:attributeGroup ref="tei:att.canonical.attribute.key"/>
+      <xs:attributeGroup ref="tei:att.canonical.attribute.ref"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.canonical.attribute.key">
+      <xs:attribute name="key" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>provides an externally-defined means of identifying the entity (or entities) being named, using a coded value of some kind.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.canonical.attribute.ref">
+      <xs:attribute name="ref">
+         <xs:annotation>
+            <xs:documentation>(reference) provides an explicit means of locating a full definition or identity for the entity being named by means of one or more URIs.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.citing.attributes">
+      <xs:attributeGroup ref="tei:att.citing.attribute.unit"/>
+      <xs:attributeGroup ref="tei:att.citing.attribute.from"/>
+      <xs:attributeGroup ref="tei:att.citing.attribute.to"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.citing.attribute.unit">
+      <xs:attribute name="unit">
+         <xs:annotation>
+            <xs:documentation>identifies the unit of information conveyed by the element.
+Suggested values include: 1] volume (volume); 2] issue; 3] page (page); 4] line; 5] chapter (chapter); 6] part; 7] column; 8] entry</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="volume">
+                        <xs:annotation>
+                           <xs:documentation>(volume) the element contains a volume number.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="issue">
+                        <xs:annotation>
+                           <xs:documentation>the element contains an issue number, or volume and issue numbers.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="page">
+                        <xs:annotation>
+                           <xs:documentation>(page) the element contains a page number or page range.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="line">
+                        <xs:annotation>
+                           <xs:documentation>the element contains a line number or line range.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="chapter">
+                        <xs:annotation>
+                           <xs:documentation>(chapter) the element contains a chapter indication (number and/or title)</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="part">
+                        <xs:annotation>
+                           <xs:documentation>the element identifies a part of a book or collection.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="column">
+                        <xs:annotation>
+                           <xs:documentation>the element identifies a column.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="entry">
+                        <xs:annotation>
+                           <xs:documentation>the element identifies an entry number or label in a list of entries.</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.citing.attribute.from">
+      <xs:attribute name="from">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.citing.attribute.to">
+      <xs:attribute name="to">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.cmc.attributes">
+      <xs:attributeGroup ref="tei:att.cmc.attribute.generatedBy"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.cmc.attribute.generatedBy">
+      <xs:attribute name="generatedBy">
+         <xs:annotation>
+            <xs:documentation>(generated by) categorizes how the content of an element was generated in a CMC environment.
+Suggested values include: 1] human; 2] template; 3] system; 4] bot; 5] unspecified</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="human">
+                        <xs:annotation>
+                           <xs:documentation>the content was naturally typed or spoken by a human user</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="template">
+                        <xs:annotation>
+                           <xs:documentation>the content was generated after a human user activated a template for its insertion</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="system">
+                        <xs:annotation>
+                           <xs:documentation>the content was generated by the system, i.e. the CMC environment</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="bot">
+                        <xs:annotation>
+                           <xs:documentation>the content was generated by a bot, i.e. a non-human agent, typically one that is not part of the CMC environment itself</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="unspecified">
+                        <xs:annotation>
+                           <xs:documentation>the content was generated by an unknown or unspecified process</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.w3c.attributes">
+      <xs:attributeGroup ref="tei:att.datable.w3c.attribute.when"/>
+      <xs:attributeGroup ref="tei:att.datable.w3c.attribute.notBefore"/>
+      <xs:attributeGroup ref="tei:att.datable.w3c.attribute.notAfter"/>
+      <xs:attributeGroup ref="tei:att.datable.w3c.attribute.from"/>
+      <xs:attributeGroup ref="tei:att.datable.w3c.attribute.to"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.w3c.attribute.when">
+      <xs:attribute name="when">
+         <xs:annotation>
+            <xs:documentation>supplies the value of the date or time in a standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime"/>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.w3c.attribute.notBefore">
+      <xs:attribute name="notBefore">
+         <xs:annotation>
+            <xs:documentation>specifies the earliest possible date for the event in standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime"/>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.w3c.attribute.notAfter">
+      <xs:attribute name="notAfter">
+         <xs:annotation>
+            <xs:documentation>specifies the latest possible date for the event in standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime"/>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.w3c.attribute.from">
+      <xs:attribute name="from">
+         <xs:annotation>
+            <xs:documentation>indicates the starting point of the period in standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime"/>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.w3c.attribute.to">
+      <xs:attribute name="to">
+         <xs:annotation>
+            <xs:documentation>indicates the ending point of the period in standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime"/>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datcat.attributes">
+      <xs:attributeGroup ref="tei:att.datcat.attribute.datcat"/>
+      <xs:attributeGroup ref="tei:att.datcat.attribute.valueDatcat"/>
+      <xs:attributeGroup ref="tei:att.datcat.attribute.targetDatcat"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datcat.attribute.datcat">
+      <xs:attribute name="datcat">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datcat.attribute.valueDatcat">
+      <xs:attribute name="valueDatcat">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datcat.attribute.targetDatcat">
+      <xs:attribute name="targetDatcat">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.declarable.attributes">
+      <xs:attributeGroup ref="tei:att.declarable.attribute.default"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.declarable.attribute.default">
+      <xs:attribute name="default" default="false">
+         <xs:annotation>
+            <xs:documentation>indicates whether or not this element is selected by default when its parent is selected.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true">
+                  <xs:annotation>
+                     <xs:documentation>This element is selected if its parent is selected</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="false">
+                  <xs:annotation>
+                     <xs:documentation>This element can only be selected explicitly, unless it is the only one of its kind, in which case it is selected if its parent is selected.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.docStatus.attributes">
+      <xs:attributeGroup ref="tei:att.docStatus.attribute.status"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.docStatus.attribute.status">
+      <xs:attribute name="status" default="draft">
+         <xs:annotation>
+            <xs:documentation>describes the status of a document either currently or, when associated with a dated element, at the time indicated.
+Sample values include: 1] approved; 2] candidate; 3] cleared; 4] deprecated; 5] draft; 6] embargoed; 7] expired; 8] frozen; 9] galley; 10] proposed; 11] published; 12] recommendation; 13] submitted; 14] unfinished; 15] withdrawn</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.editLike.attributes">
+      <xs:attributeGroup ref="tei:att.editLike.attribute.evidence"/>
+      <xs:attributeGroup ref="tei:att.editLike.attribute.instant"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.editLike.attribute.evidence">
+      <xs:attribute name="evidence">
+         <xs:annotation>
+            <xs:documentation>indicates the nature of the evidence supporting the reliability or accuracy of the intervention or interpretation.
+Suggested values include: 1] internal; 2] external; 3] conjecture</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:union>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="internal">
+                                    <xs:annotation>
+                                       <xs:documentation>there is internal evidence to support the intervention.</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="external">
+                                    <xs:annotation>
+                                       <xs:documentation>there is external evidence to support the intervention.</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="conjecture">
+                                    <xs:annotation>
+                                       <xs:documentation>the intervention or interpretation has been made by the editor, cataloguer, or scholar on the basis of their expertise.</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                              </xs:restriction>
+                           </xs:simpleType>
+                        </xs:union>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.editLike.attribute.instant">
+      <xs:attribute name="instant" default="false">
+         <xs:annotation>
+            <xs:documentation>indicates whether this is an instant revision or not.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:boolean">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="unknown">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                     <xs:enumeration value="inapplicable">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.fragmentable.attributes">
+      <xs:attributeGroup ref="tei:att.fragmentable.attribute.part"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.fragmentable.attribute.part">
+      <xs:attribute name="part" default="N">
+         <xs:annotation>
+            <xs:documentation>specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="Y">
+                  <xs:annotation>
+                     <xs:documentation>(yes) the element is fragmented in some (unspecified) respect</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="N">
+                  <xs:annotation>
+                     <xs:documentation>(no) the element is not fragmented, or no claim is made as to its completeness</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="I">
+                  <xs:annotation>
+                     <xs:documentation>(initial) this is the initial part of a fragmented element</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="M">
+                  <xs:annotation>
+                     <xs:documentation>(medial) this is a medial part of a fragmented element</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="F">
+                  <xs:annotation>
+                     <xs:documentation>(final) this is the final part of a fragmented element</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.rendition.attributes">
+      <xs:attributeGroup ref="tei:att.global.rendition.attribute.rend"/>
+      <xs:attributeGroup ref="tei:att.global.rendition.attribute.style"/>
+      <xs:attributeGroup ref="tei:att.global.rendition.attribute.rendition"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.rendition.attribute.rend">
+      <xs:attribute name="rend">
+         <xs:annotation>
+            <xs:documentation>(rendition) indicates how the element in question was rendered or presented in the source text.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.rendition.attribute.style">
+      <xs:attribute name="style" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>contains an expression in some formal style definition language which defines the rendering or presentation used for this element in the source text.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.rendition.attribute.rendition">
+      <xs:attribute name="rendition">
+         <xs:annotation>
+            <xs:documentation>points to a description of the rendering or presentation used for this element in the source text.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.responsibility.attributes">
+      <xs:attributeGroup ref="tei:att.global.responsibility.attribute.cert"/>
+      <xs:attributeGroup ref="tei:att.global.responsibility.attribute.resp"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.responsibility.attribute.cert">
+      <xs:attribute name="cert">
+         <xs:annotation>
+            <xs:documentation>(certainty) signifies the degree of certainty associated with the intervention or interpretation.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:double">
+                     <xs:minInclusive value="0"/>
+                     <xs:maxInclusive value="1"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="high">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                     <xs:enumeration value="medium">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                     <xs:enumeration value="low">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                     <xs:enumeration value="unknown">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.responsibility.attribute.resp">
+      <xs:attribute name="resp">
+         <xs:annotation>
+            <xs:documentation>(responsible party) indicates the agency responsible for the intervention or interpretation, for example an editor or transcriber.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.source.attributes">
+      <xs:attributeGroup ref="tei:att.global.source.attribute.source"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.source.attribute.source">
+      <xs:attribute name="source">
+         <xs:annotation>
+            <xs:documentation>specifies the source from which some aspect of this element is drawn.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.internetMedia.attributes">
+      <xs:attributeGroup ref="tei:att.internetMedia.attribute.mimeType"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.internetMedia.attribute.mimeType">
+      <xs:attribute name="mimeType">
+         <xs:annotation>
+            <xs:documentation>(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.measurement.attributes">
+      <xs:attributeGroup ref="tei:att.measurement.attribute.unit"/>
+      <xs:attributeGroup ref="tei:att.measurement.attribute.unitRef"/>
+      <xs:attributeGroup ref="tei:att.measurement.attribute.quantity"/>
+      <xs:attributeGroup ref="tei:att.measurement.attribute.commodity"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.measurement.attribute.unit">
+      <xs:attribute name="unit">
+         <xs:annotation>
+            <xs:documentation>(unit) indicates the units used for the measurement, usually using the standard symbol for the desired units.
+Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="m">
+                        <xs:annotation>
+                           <xs:documentation>(metre) SI base unit of length</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="kg">
+                        <xs:annotation>
+                           <xs:documentation>(kilogram) SI base unit of mass</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="s">
+                        <xs:annotation>
+                           <xs:documentation>(second) SI base unit of time</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="Hz">
+                        <xs:annotation>
+                           <xs:documentation>(hertz) SI unit of frequency</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="Pa">
+                        <xs:annotation>
+                           <xs:documentation>(pascal) SI unit of pressure or stress</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="Ω">
+                        <xs:annotation>
+                           <xs:documentation>(ohm) SI unit of electric resistance</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="L">
+                        <xs:annotation>
+                           <xs:documentation>(litre) 1 dm³</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="t">
+                        <xs:annotation>
+                           <xs:documentation>(tonne) 10³ kg</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="ha">
+                        <xs:annotation>
+                           <xs:documentation>(hectare) 1 hm²</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="Å">
+                        <xs:annotation>
+                           <xs:documentation>(ångström) 10⁻¹⁰ m</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="mL">
+                        <xs:annotation>
+                           <xs:documentation>(millilitre) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="cm">
+                        <xs:annotation>
+                           <xs:documentation>(centimetre) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="dB">
+                        <xs:annotation>
+                           <xs:documentation>(decibel) see remarks, below</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="kbit">
+                        <xs:annotation>
+                           <xs:documentation>(kilobit) 10³ or 1000 bits</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="Kibit">
+                        <xs:annotation>
+                           <xs:documentation>(kibibit) 2¹⁰ or 1024 bits</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="kB">
+                        <xs:annotation>
+                           <xs:documentation>(kilobyte) 10³ or 1000 bytes</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="KiB">
+                        <xs:annotation>
+                           <xs:documentation>(kibibyte) 2¹⁰ or 1024 bytes</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="MB">
+                        <xs:annotation>
+                           <xs:documentation>(megabyte) 10⁶ or 1 000 000 bytes</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="MiB">
+                        <xs:annotation>
+                           <xs:documentation>(mebibyte) 2²⁰ or 1 048 576 bytes</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.measurement.attribute.unitRef">
+      <xs:attribute name="unitRef">
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.measurement.attribute.quantity">
+      <xs:attribute name="quantity">
+         <xs:annotation>
+            <xs:documentation>(quantity) specifies the number of the specified units that comprise the measurement</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.measurement.attribute.commodity">
+      <xs:attribute name="commodity">
+         <xs:annotation>
+            <xs:documentation>(commodity) indicates the substance that is being measured</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.notated.attributes">
+      <xs:attributeGroup ref="tei:att.notated.attribute.notation"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.notated.attribute.notation">
+      <xs:attribute name="notation">
+         <xs:annotation>
+            <xs:documentation>names the notation used for the content of the element.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.placement.attributes">
+      <xs:attributeGroup ref="tei:att.placement.attribute.place"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.placement.attribute.place">
+      <xs:attribute name="place">
+         <xs:annotation>
+            <xs:documentation>specifies where this item is placed.
+Suggested values include: 1] top; 2] bottom; 3] margin; 4] opposite; 5] overleaf; 6] above; 7] right; 8] below; 9] left; 10] end; 11] inline; 12] inspace</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:union>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="top">
+                                    <xs:annotation>
+                                       <xs:documentation>at the top of the page</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="bottom">
+                                    <xs:annotation>
+                                       <xs:documentation>at the foot of the page</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="margin">
+                                    <xs:annotation>
+                                       <xs:documentation>in the margin (left, right, or both)</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="opposite">
+                                    <xs:annotation>
+                                       <xs:documentation>on the opposite, i.e. facing, page</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="overleaf">
+                                    <xs:annotation>
+                                       <xs:documentation>on the other side of the leaf</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="above">
+                                    <xs:annotation>
+                                       <xs:documentation>above the line</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="right">
+                                    <xs:annotation>
+                                       <xs:documentation>to the right, e.g. to the right of a vertical line of text, or to the right of a figure</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="below">
+                                    <xs:annotation>
+                                       <xs:documentation>below the line</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="left">
+                                    <xs:annotation>
+                                       <xs:documentation>to the left, e.g. to the left of a vertical line of text, or to the left of a figure</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="end">
+                                    <xs:annotation>
+                                       <xs:documentation>at the end of e.g. chapter or volume.</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="inline">
+                                    <xs:annotation>
+                                       <xs:documentation>within the body of the text.</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="inspace">
+                                    <xs:annotation>
+                                       <xs:documentation>in a predefined space, for example left by an earlier scribe.</xs:documentation>
+                                    </xs:annotation>
+                                 </xs:enumeration>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                              </xs:restriction>
+                           </xs:simpleType>
+                        </xs:union>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.pointing.attributes">
+      <xs:attributeGroup ref="tei:att.pointing.attribute.targetLang"/>
+      <xs:attributeGroup ref="tei:att.pointing.attribute.target"/>
+      <xs:attributeGroup ref="tei:att.pointing.attribute.evaluate"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.pointing.attribute.targetLang">
+      <xs:attribute name="targetLang">
+         <xs:simpleType>
+            <xs:union memberTypes="xs:language">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.pointing.attribute.target">
+      <xs:attribute name="target">
+         <xs:annotation>
+            <xs:documentation>specifies the destination of the reference by supplying one or more URI References.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.pointing.attribute.evaluate">
+      <xs:attribute name="evaluate">
+         <xs:annotation>
+            <xs:documentation>(evaluate) specifies the intended meaning when the target of a pointer is itself a pointer.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="all">
+                  <xs:annotation>
+                     <xs:documentation>if the element pointed to is itself a pointer, then the target of that pointer will be taken, and so on, until an element is found which is not a pointer.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="one">
+                  <xs:annotation>
+                     <xs:documentation>if the element pointed to is itself a pointer, then its target (whether a pointer or not) is taken as the target of this pointer.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="none">
+                  <xs:annotation>
+                     <xs:documentation>no further evaluation of targets is carried out beyond that needed to find the element specified in the pointer's target.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ranging.attributes">
+      <xs:attributeGroup ref="tei:att.ranging.attribute.atLeast"/>
+      <xs:attributeGroup ref="tei:att.ranging.attribute.atMost"/>
+      <xs:attributeGroup ref="tei:att.ranging.attribute.min"/>
+      <xs:attributeGroup ref="tei:att.ranging.attribute.max"/>
+      <xs:attributeGroup ref="tei:att.ranging.attribute.confidence"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ranging.attribute.atLeast">
+      <xs:attribute name="atLeast">
+         <xs:annotation>
+            <xs:documentation>gives a minimum estimated value for the approximate measurement.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ranging.attribute.atMost">
+      <xs:attribute name="atMost">
+         <xs:annotation>
+            <xs:documentation>gives a maximum estimated value for the approximate measurement.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ranging.attribute.min">
+      <xs:attribute name="min">
+         <xs:annotation>
+            <xs:documentation>where the measurement summarizes more than one observation or a range, supplies the minimum value observed.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ranging.attribute.max">
+      <xs:attribute name="max">
+         <xs:annotation>
+            <xs:documentation>where the measurement summarizes more than one observation or a range, supplies the maximum value observed.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.ranging.attribute.confidence">
+      <xs:attribute name="confidence">
+         <xs:simpleType>
+            <xs:restriction base="xs:double">
+               <xs:minInclusive value="0"/>
+               <xs:maxInclusive value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.resourced.attributes">
+      <xs:attributeGroup ref="tei:att.resourced.attribute.url"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.resourced.attribute.url">
+      <xs:attribute name="url" use="required">
+         <xs:annotation>
+            <xs:documentation>(uniform resource locator) specifies the URL from which the media concerned may be obtained.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.sortable.attributes">
+      <xs:attributeGroup ref="tei:att.sortable.attribute.sortKey"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.sortable.attribute.sortKey">
+      <xs:attribute name="sortKey">
+         <xs:annotation>
+            <xs:documentation>supplies the sort key for this element in an index, list or group which contains it.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.spanning.attributes">
+      <xs:attributeGroup ref="tei:att.spanning.attribute.spanTo"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.spanning.attribute.spanTo">
+      <xs:attribute name="spanTo">
+         <xs:annotation>
+            <xs:documentation>indicates the end of a span initiated by the element bearing this attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.styleDef.attributes">
+      <xs:attributeGroup ref="tei:att.styleDef.attribute.scheme"/>
+      <xs:attributeGroup ref="tei:att.styleDef.attribute.schemeVersion"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.styleDef.attribute.scheme">
+      <xs:attribute name="scheme">
+         <xs:annotation>
+            <xs:documentation>identifies the language used to describe the rendition.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="css">
+                  <xs:annotation>
+                     <xs:documentation>Cascading Stylesheet Language</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="xslfo">
+                  <xs:annotation>
+                     <xs:documentation>Extensible Stylesheet Language Formatting Objects</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="free">
+                  <xs:annotation>
+                     <xs:documentation>Informal free text description</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="other">
+                  <xs:annotation>
+                     <xs:documentation>A user-defined rendition description language</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.styleDef.attribute.schemeVersion">
+      <xs:attribute name="schemeVersion">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.typed.attributes">
+      <xs:attributeGroup ref="tei:att.typed.attribute.type"/>
+      <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.typed.attribute.type">
+      <xs:attribute name="type">
+         <xs:annotation>
+            <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.typed.attribute.subtype">
+      <xs:attribute name="subtype">
+         <xs:annotation>
+            <xs:documentation>(subtype) provides a sub-categorization of the element, if needed.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.written.attributes">
+      <xs:attributeGroup ref="tei:att.written.attribute.hand"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.written.attribute.hand">
+      <xs:attribute name="hand">
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.attributes">
+      <xs:attributeGroup ref="tei:att.datable.custom.attributes"/>
+      <xs:attributeGroup ref="tei:att.datable.iso.attributes"/>
+      <xs:attributeGroup ref="tei:att.datable.w3c.attributes"/>
+      <xs:attributeGroup ref="tei:att.datable.attribute.period"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.attribute.period">
+      <xs:attribute name="period">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.dimensions.attributes">
+      <xs:attributeGroup ref="tei:att.ranging.attributes"/>
+      <xs:attributeGroup ref="tei:att.dimensions.attribute.unit"/>
+      <xs:attributeGroup ref="tei:att.dimensions.attribute.quantity"/>
+      <xs:attributeGroup ref="tei:att.dimensions.attribute.extent"/>
+      <xs:attributeGroup ref="tei:att.dimensions.attribute.precision"/>
+      <xs:attributeGroup ref="tei:att.dimensions.attribute.scope"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.dimensions.attribute.unit">
+      <xs:attribute name="unit">
+         <xs:annotation>
+            <xs:documentation>names the unit used for the measurement
+Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] line; 5] char (characters)</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="cm">
+                        <xs:annotation>
+                           <xs:documentation>(centimetres) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="mm">
+                        <xs:annotation>
+                           <xs:documentation>(millimetres) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="in">
+                        <xs:annotation>
+                           <xs:documentation>(inches) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="line">
+                        <xs:annotation>
+                           <xs:documentation>lines of text</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="char">
+                        <xs:annotation>
+                           <xs:documentation>(characters) characters of text</xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.dimensions.attribute.quantity">
+      <xs:attribute name="quantity">
+         <xs:annotation>
+            <xs:documentation>specifies the length in the units specified</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.dimensions.attribute.extent">
+      <xs:attribute name="extent" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>indicates the size of the object concerned using a project-specific vocabulary combining quantity and units in a single string of words.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.dimensions.attribute.precision">
+      <xs:attribute name="precision">
+         <xs:annotation>
+            <xs:documentation>characterizes the precision of the values specified by the other attributes.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="high">
+                  <xs:annotation>
+                     <xs:documentation/>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="medium">
+                  <xs:annotation>
+                     <xs:documentation/>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="low">
+                  <xs:annotation>
+                     <xs:documentation/>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="unknown">
+                  <xs:annotation>
+                     <xs:documentation/>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.dimensions.attribute.scope">
+      <xs:attribute name="scope">
+         <xs:annotation>
+            <xs:documentation>where the measurement summarizes more than one observation, specifies the applicability of this measurement.
+Sample values include: 1] all; 2] most; 3] range</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.attributes">
+      <xs:attributeGroup ref="tei:att.global.analytic.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.change.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.facs.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.rendition.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.responsibility.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.source.attributes"/>
+      <xs:attributeGroup ref="tei:att.global.attribute.xmlid"/>
+      <xs:attributeGroup ref="tei:att.global.attribute.n"/>
+      <xs:attributeGroup ref="tei:att.global.attribute.xmllang"/>
+      <xs:attributeGroup ref="tei:att.global.attribute.xmlbase"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.attribute.xmlid">
+      <xs:attribute ref="xml:id"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.attribute.n">
+      <xs:attribute name="n" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(number) gives a number (or other label) for an element, which is not necessarily unique within the document.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.attribute.xmllang">
+      <xs:attribute ref="xml:lang"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.attribute.xmlbase">
+      <xs:attribute ref="xml:base"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.media.attributes">
+      <xs:attributeGroup ref="tei:att.internetMedia.attributes"/>
+      <xs:attributeGroup ref="tei:att.media.attribute.width"/>
+      <xs:attributeGroup ref="tei:att.media.attribute.height"/>
+      <xs:attributeGroup ref="tei:att.media.attribute.scale"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.media.attribute.width">
+      <xs:attribute name="width">
+         <xs:annotation>
+            <xs:documentation>Where the media are displayed, indicates the display width.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|ch|rem|vw|vh|vmin|vmax)"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.media.attribute.height">
+      <xs:attribute name="height">
+         <xs:annotation>
+            <xs:documentation>Where the media are displayed, indicates the display height.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|ch|rem|vw|vh|vmin|vmax)"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.media.attribute.scale">
+      <xs:attribute name="scale">
+         <xs:annotation>
+            <xs:documentation>Where the media are displayed, indicates a scale factor to be applied when generating the desired display size.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:double xs:decimal">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.naming.attributes">
+      <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+      <xs:attributeGroup ref="tei:att.naming.attribute.role"/>
+      <xs:attributeGroup ref="tei:att.naming.attribute.nymRef"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.naming.attribute.role">
+      <xs:attribute name="role">
+         <xs:annotation>
+            <xs:documentation>may be used to specify further information about the entity referenced by this name in the form of a set of whitespace-separated values, for example the occupation of a person, or the status of a place.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.naming.attribute.nymRef">
+      <xs:attribute name="nymRef">
+         <xs:annotation>
+            <xs:documentation>(reference to the canonical name) provides a means of locating the canonical form (nym) of the names associated with the object named by the element bearing it.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.segLike.attributes">
+      <xs:attributeGroup ref="tei:att.datcat.attributes"/>
+      <xs:attributeGroup ref="tei:att.fragmentable.attributes"/>
+      <xs:attributeGroup ref="tei:att.segLike.attribute.function"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.segLike.attribute.function">
+      <xs:attribute name="function">
+         <xs:annotation>
+            <xs:documentation>(function) characterizes the function of the segment.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.transcriptional.attributes">
+      <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+      <xs:attributeGroup ref="tei:att.placement.attributes"/>
+      <xs:attributeGroup ref="tei:att.written.attributes"/>
+      <xs:attributeGroup ref="tei:att.transcriptional.attribute.status"/>
+      <xs:attributeGroup ref="tei:att.transcriptional.attribute.cause"/>
+      <xs:attributeGroup ref="tei:att.transcriptional.attribute.seq"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.transcriptional.attribute.status">
+      <xs:attribute name="status" default="unremarkable">
+         <xs:annotation>
+            <xs:documentation>indicates the effect of the intervention, for example in the case of a deletion, strikeouts which include too much or too little text, or in the case of an addition, an insertion which duplicates some of the text already present.
+Sample values include: 1] duplicate; 2] duplicate-partial; 3] excessStart; 4] excessEnd; 5] shortStart; 6] shortEnd; 7] partial; 8] unremarkable</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.transcriptional.attribute.cause">
+      <xs:attribute name="cause">
+         <xs:annotation>
+            <xs:documentation>documents the presumed cause for the intervention.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.transcriptional.attribute.seq">
+      <xs:attribute name="seq" type="xs:nonNegativeInteger">
+         <xs:annotation>
+            <xs:documentation>(sequence) assigns a sequence number related to the order in which the encoded features carrying this attribute are believed to have occurred.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:group name="model.nameLike.agent">
+      <xs:choice>
+         <xs:element ref="tei:name"/>
+         <xs:element ref="tei:orgName"/>
+         <xs:element ref="tei:persName"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.nameLike.agent_alternation">
+      <xs:choice>
+         <xs:element ref="tei:name"/>
+         <xs:element ref="tei:orgName"/>
+         <xs:element ref="tei:persName"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.nameLike.agent_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:name"/>
+         <xs:element ref="tei:orgName"/>
+         <xs:element ref="tei:persName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.nameLike.agent_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:name"/>
+         <xs:element minOccurs="0" ref="tei:orgName"/>
+         <xs:element minOccurs="0" ref="tei:persName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.nameLike.agent_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:name"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:orgName"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:persName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.nameLike.agent_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:name"/>
+         <xs:element maxOccurs="unbounded" ref="tei:orgName"/>
+         <xs:element maxOccurs="unbounded" ref="tei:persName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.segLike">
+      <xs:choice>
+         <xs:element ref="tei:c"/>
+         <xs:element ref="tei:pc"/>
+         <xs:element ref="tei:seg"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.segLike_alternation">
+      <xs:choice>
+         <xs:element ref="tei:c"/>
+         <xs:element ref="tei:pc"/>
+         <xs:element ref="tei:seg"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.segLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:c"/>
+         <xs:element ref="tei:pc"/>
+         <xs:element ref="tei:seg"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.segLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:c"/>
+         <xs:element minOccurs="0" ref="tei:pc"/>
+         <xs:element minOccurs="0" ref="tei:seg"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.segLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:c"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:pc"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:seg"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.segLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:c"/>
+         <xs:element maxOccurs="unbounded" ref="tei:pc"/>
+         <xs:element maxOccurs="unbounded" ref="tei:seg"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.hiLike">
+      <xs:sequence>
+         <xs:element ref="tei:hi"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.hiLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:hi"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.hiLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:hi"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.hiLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:hi"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.hiLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:hi"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.hiLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:hi"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.emphLike">
+      <xs:choice>
+         <xs:element ref="tei:term"/>
+         <xs:element ref="tei:title"/>
+         <xs:element ref="tei:ident"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.emphLike_alternation">
+      <xs:choice>
+         <xs:element ref="tei:term"/>
+         <xs:element ref="tei:title"/>
+         <xs:element ref="tei:ident"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.emphLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:term"/>
+         <xs:element ref="tei:title"/>
+         <xs:element ref="tei:ident"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.emphLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:term"/>
+         <xs:element minOccurs="0" ref="tei:title"/>
+         <xs:element minOccurs="0" ref="tei:ident"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.emphLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:term"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:title"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:ident"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.emphLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:term"/>
+         <xs:element maxOccurs="unbounded" ref="tei:title"/>
+         <xs:element maxOccurs="unbounded" ref="tei:ident"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.highlighted">
+      <xs:sequence>
+         <xs:group ref="tei:model.emphLike"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.highlighted_alternation">
+      <xs:sequence>
+         <xs:group ref="tei:model.emphLike_alternation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.highlighted_sequence">
+      <xs:sequence>
+         <xs:group ref="tei:model.emphLike_sequence"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.highlighted_sequenceOptional">
+      <xs:sequence>
+         <xs:group minOccurs="0" ref="tei:model.emphLike_sequenceOptional"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.highlighted_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.emphLike_sequenceOptionalRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.highlighted_sequenceRepeatable">
+      <xs:sequence>
+         <xs:group maxOccurs="unbounded" ref="tei:model.emphLike_sequenceRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.dateLike">
+      <xs:sequence>
+         <xs:element ref="tei:date"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.dateLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:date"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.dateLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:date"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.dateLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:date"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.dateLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:date"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.dateLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:date"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.graphicLike">
+      <xs:sequence>
+         <xs:element ref="tei:graphic"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.graphicLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:graphic"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.graphicLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:graphic"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.graphicLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:graphic"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.graphicLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:graphic"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.graphicLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:graphic"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.editorial">
+      <xs:choice>
+         <xs:element ref="tei:abbr"/>
+         <xs:element ref="tei:expan"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.pPart.editorial_alternation">
+      <xs:choice>
+         <xs:element ref="tei:abbr"/>
+         <xs:element ref="tei:expan"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.pPart.editorial_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:abbr"/>
+         <xs:element ref="tei:expan"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.editorial_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:abbr"/>
+         <xs:element minOccurs="0" ref="tei:expan"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.editorial_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:abbr"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:expan"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.editorial_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:abbr"/>
+         <xs:element maxOccurs="unbounded" ref="tei:expan"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.edit">
+      <xs:sequence>
+         <xs:group ref="tei:model.pPart.editorial"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.edit_alternation">
+      <xs:sequence>
+         <xs:group ref="tei:model.pPart.editorial_alternation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.edit_sequence">
+      <xs:sequence>
+         <xs:group ref="tei:model.pPart.editorial_sequence"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.edit_sequenceOptional">
+      <xs:sequence>
+         <xs:group minOccurs="0" ref="tei:model.pPart.editorial_sequenceOptional"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.edit_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.pPart.editorial_sequenceOptionalRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.ptrLike">
+      <xs:sequence>
+         <xs:element ref="tei:ref"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.ptrLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:ref"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.ptrLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:ref"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.ptrLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:ref"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.ptrLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:ref"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.ptrLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:ref"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="model.gLike" abstract="true">
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attribute name="ref">
+            <xs:annotation>
+               <xs:documentation>points to a description of the character or glyph intended.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:anyURI">
+                  <xs:pattern value="\S+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="model.biblLike">
+      <xs:choice>
+         <xs:element ref="tei:bibl"/>
+         <xs:element ref="tei:biblStruct"/>
+         <xs:element ref="tei:listBibl"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.biblLike_alternation">
+      <xs:choice>
+         <xs:element ref="tei:bibl"/>
+         <xs:element ref="tei:biblStruct"/>
+         <xs:element ref="tei:listBibl"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.biblLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:bibl"/>
+         <xs:element ref="tei:biblStruct"/>
+         <xs:element ref="tei:listBibl"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.biblLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:bibl"/>
+         <xs:element minOccurs="0" ref="tei:biblStruct"/>
+         <xs:element minOccurs="0" ref="tei:listBibl"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.biblLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:bibl"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:biblStruct"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:listBibl"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.biblLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:bibl"/>
+         <xs:element maxOccurs="unbounded" ref="tei:biblStruct"/>
+         <xs:element maxOccurs="unbounded" ref="tei:listBibl"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.headLike">
+      <xs:sequence>
+         <xs:element ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.headLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.headLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.headLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.headLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.headLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.labelLike">
+      <xs:sequence>
+         <xs:element ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.labelLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.labelLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.labelLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.labelLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.labelLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.listLike">
+      <xs:sequence>
+         <xs:element ref="tei:list"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.listLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:list"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.listLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:list"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.listLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:list"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.listLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:list"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.listLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:list"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.noteLike">
+      <xs:sequence>
+         <xs:element ref="tei:note"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.noteLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:note"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.noteLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:note"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.noteLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:note"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.noteLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:note"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.noteLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:note"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike">
+      <xs:sequence>
+         <xs:element ref="tei:p"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:p"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:p"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:p"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:p"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:p"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.entryPart">
+      <xs:choice>
+         <xs:element ref="tei:sense"/>
+         <xs:element ref="tei:form"/>
+         <xs:element ref="tei:orth"/>
+         <xs:element ref="tei:pron"/>
+         <xs:element ref="tei:gramGrp"/>
+         <xs:element ref="tei:etym"/>
+         <xs:element ref="tei:usg"/>
+         <xs:element ref="tei:lbl"/>
+         <xs:element ref="tei:xr"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.entryPart.top">
+      <xs:choice>
+         <xs:group ref="tei:model.biblLike"/>
+         <xs:element ref="tei:cit"/>
+         <xs:element ref="tei:num"/>
+         <xs:element ref="tei:entry"/>
+         <xs:element ref="tei:form"/>
+         <xs:element ref="tei:gramGrp"/>
+         <xs:element ref="tei:etym"/>
+         <xs:element ref="tei:usg"/>
+         <xs:element ref="tei:lbl"/>
+         <xs:element ref="tei:xr"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.divPart">
+      <xs:sequence>
+         <xs:group ref="tei:model.pLike"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.persStateLike">
+      <xs:choice>
+         <xs:element ref="tei:persName"/>
+         <xs:element ref="tei:affiliation"/>
+         <xs:element ref="tei:age"/>
+         <xs:element ref="tei:education"/>
+         <xs:element ref="tei:faith"/>
+         <xs:element ref="tei:floruit"/>
+         <xs:element ref="tei:gender"/>
+         <xs:element ref="tei:langKnowledge"/>
+         <xs:element ref="tei:nationality"/>
+         <xs:element ref="tei:occupation"/>
+         <xs:element ref="tei:persona"/>
+         <xs:element ref="tei:persPronouns"/>
+         <xs:element ref="tei:residence"/>
+         <xs:element ref="tei:sex"/>
+         <xs:element ref="tei:socecStatus"/>
+         <xs:element ref="tei:state"/>
+         <xs:element ref="tei:trait"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.personPart">
+      <xs:choice>
+         <xs:group ref="tei:model.biblLike"/>
+         <xs:group ref="tei:model.persStateLike"/>
+         <xs:element ref="tei:name"/>
+         <xs:element ref="tei:idno"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.placeNamePart">
+      <xs:sequence>
+         <xs:element ref="tei:placeName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeNamePart_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:placeName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeNamePart_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:placeName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeNamePart_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:placeName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeNamePart_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:placeName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeNamePart_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:placeName"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeStateLike">
+      <xs:choice>
+         <xs:group ref="tei:model.placeNamePart"/>
+         <xs:element ref="tei:state"/>
+         <xs:element ref="tei:trait"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.placeStateLike_alternation">
+      <xs:choice>
+         <xs:group ref="tei:model.placeNamePart_alternation"/>
+         <xs:element ref="tei:state"/>
+         <xs:element ref="tei:trait"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.placeStateLike_sequence">
+      <xs:sequence>
+         <xs:group ref="tei:model.placeNamePart_sequence"/>
+         <xs:element ref="tei:state"/>
+         <xs:element ref="tei:trait"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeStateLike_sequenceOptional">
+      <xs:sequence>
+         <xs:group minOccurs="0" ref="tei:model.placeNamePart_sequenceOptional"/>
+         <xs:element minOccurs="0" ref="tei:state"/>
+         <xs:element minOccurs="0" ref="tei:trait"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeStateLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.placeNamePart_sequenceOptionalRepeatable"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:state"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:trait"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.placeStateLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:group maxOccurs="unbounded" ref="tei:model.placeNamePart_sequenceRepeatable"/>
+         <xs:element maxOccurs="unbounded" ref="tei:state"/>
+         <xs:element maxOccurs="unbounded" ref="tei:trait"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.publicationStmtPart.agency">
+      <xs:choice>
+         <xs:element ref="tei:publisher"/>
+         <xs:element ref="tei:authority"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="model.availabilityPart" abstract="true">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.specialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.pointing.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="model.descLike">
+      <xs:sequence>
+         <xs:element ref="tei:desc"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.quoteLike">
+      <xs:choice>
+         <xs:element ref="tei:quote"/>
+         <xs:element ref="tei:cit"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.quoteLike_alternation">
+      <xs:choice>
+         <xs:element ref="tei:quote"/>
+         <xs:element ref="tei:cit"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.quoteLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:quote"/>
+         <xs:element ref="tei:cit"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.quoteLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:quote"/>
+         <xs:element minOccurs="0" ref="tei:cit"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.quoteLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:quote"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:cit"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.quoteLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:quote"/>
+         <xs:element maxOccurs="unbounded" ref="tei:cit"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.attributable">
+      <xs:sequence>
+         <xs:group ref="tei:model.quoteLike"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.attributable_alternation">
+      <xs:sequence>
+         <xs:group ref="tei:model.quoteLike_alternation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.attributable_sequence">
+      <xs:sequence>
+         <xs:group ref="tei:model.quoteLike_sequence"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.attributable_sequenceOptional">
+      <xs:sequence>
+         <xs:group minOccurs="0" ref="tei:model.quoteLike_sequenceOptional"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.attributable_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.quoteLike_sequenceOptionalRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.attributable_sequenceRepeatable">
+      <xs:sequence>
+         <xs:group maxOccurs="unbounded" ref="tei:model.quoteLike_sequenceRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="model.respLike" abstract="true"/>
+   <xs:group name="model.divTopPart">
+      <xs:sequence>
+         <xs:group ref="tei:model.headLike"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.divTop">
+      <xs:sequence>
+         <xs:group ref="tei:model.divTopPart"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pLike.front">
+      <xs:sequence>
+         <xs:element ref="tei:head"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.imprintPart">
+      <xs:choice>
+         <xs:element ref="tei:publisher"/>
+         <xs:element ref="tei:biblScope"/>
+         <xs:element ref="tei:pubPlace"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.addressLike">
+      <xs:choice>
+         <xs:element ref="tei:email"/>
+         <xs:element ref="tei:affiliation"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.addressLike_alternation">
+      <xs:choice>
+         <xs:element ref="tei:email"/>
+         <xs:element ref="tei:affiliation"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.addressLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:email"/>
+         <xs:element ref="tei:affiliation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.addressLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:email"/>
+         <xs:element minOccurs="0" ref="tei:affiliation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.addressLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:email"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:affiliation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.addressLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:email"/>
+         <xs:element maxOccurs="unbounded" ref="tei:affiliation"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.nameLike">
+      <xs:choice>
+         <xs:group ref="tei:model.nameLike.agent"/>
+         <xs:group ref="tei:model.placeStateLike"/>
+         <xs:element ref="tei:lang"/>
+         <xs:element ref="tei:idno"/>
+         <xs:group ref="tei:model.persNamePart"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.nameLike_alternation">
+      <xs:choice>
+         <xs:group ref="tei:model.nameLike.agent_alternation"/>
+         <xs:group ref="tei:model.placeStateLike_alternation"/>
+         <xs:element ref="tei:lang"/>
+         <xs:element ref="tei:idno"/>
+         <xs:group ref="tei:model.persNamePart_alternation"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.nameLike_sequence">
+      <xs:sequence>
+         <xs:group ref="tei:model.nameLike.agent_sequence"/>
+         <xs:group ref="tei:model.placeStateLike_sequence"/>
+         <xs:element ref="tei:lang"/>
+         <xs:element ref="tei:idno"/>
+         <xs:group ref="tei:model.persNamePart_sequence"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.nameLike_sequenceOptional">
+      <xs:sequence>
+         <xs:group minOccurs="0" ref="tei:model.nameLike.agent_sequenceOptional"/>
+         <xs:group minOccurs="0" ref="tei:model.placeStateLike_sequenceOptional"/>
+         <xs:element minOccurs="0" ref="tei:lang"/>
+         <xs:element minOccurs="0" ref="tei:idno"/>
+         <xs:group minOccurs="0" ref="tei:model.persNamePart_sequenceOptional"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.nameLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.nameLike.agent_sequenceOptionalRepeatable"/>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.placeStateLike_sequenceOptionalRepeatable"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:lang"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:idno"/>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.persNamePart_sequenceOptionalRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.global">
+      <xs:choice>
+         <xs:group ref="tei:model.noteLike"/>
+         <xs:element ref="tei:figure"/>
+         <xs:element ref="tei:metamark"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.biblPart">
+      <xs:choice>
+         <xs:element ref="tei:model.respLike"/>
+         <xs:group ref="tei:model.imprintPart"/>
+         <xs:element ref="tei:quote"/>
+         <xs:element ref="tei:citedRange"/>
+         <xs:element ref="tei:bibl"/>
+         <xs:element ref="tei:edition"/>
+         <xs:element ref="tei:extent"/>
+         <xs:element ref="tei:availability"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.frontPart">
+      <xs:sequence>
+         <xs:element ref="tei:listBibl"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.data">
+      <xs:choice>
+         <xs:group ref="tei:model.dateLike"/>
+         <xs:group ref="tei:model.addressLike"/>
+         <xs:group ref="tei:model.nameLike"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.pPart.data_alternation">
+      <xs:choice>
+         <xs:group ref="tei:model.dateLike_alternation"/>
+         <xs:group ref="tei:model.addressLike_alternation"/>
+         <xs:group ref="tei:model.nameLike_alternation"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.pPart.data_sequence">
+      <xs:sequence>
+         <xs:group ref="tei:model.dateLike_sequence"/>
+         <xs:group ref="tei:model.addressLike_sequence"/>
+         <xs:group ref="tei:model.nameLike_sequence"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.data_sequenceOptional">
+      <xs:sequence>
+         <xs:group minOccurs="0" ref="tei:model.dateLike_sequenceOptional"/>
+         <xs:group minOccurs="0" ref="tei:model.addressLike_sequenceOptional"/>
+         <xs:group minOccurs="0" ref="tei:model.nameLike_sequenceOptional"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.pPart.data_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.dateLike_sequenceOptionalRepeatable"/>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.addressLike_sequenceOptionalRepeatable"/>
+         <xs:group minOccurs="0"
+                   maxOccurs="unbounded"
+                   ref="tei:model.nameLike_sequenceOptionalRepeatable"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.inter">
+      <xs:choice>
+         <xs:group ref="tei:model.biblLike"/>
+         <xs:group ref="tei:model.labelLike"/>
+         <xs:group ref="tei:model.listLike"/>
+         <xs:group ref="tei:model.attributable"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.common">
+      <xs:choice>
+         <xs:group ref="tei:model.divPart"/>
+         <xs:group ref="tei:model.inter"/>
+         <xs:element ref="tei:model.entryLike"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.phrase">
+      <xs:choice>
+         <xs:group ref="tei:model.segLike"/>
+         <xs:group ref="tei:model.highlighted"/>
+         <xs:group ref="tei:model.graphicLike"/>
+         <xs:group ref="tei:model.pPart.edit"/>
+         <xs:group ref="tei:model.ptrLike"/>
+         <xs:group ref="tei:model.pPart.data"/>
+         <xs:element ref="tei:ruby"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.paraPart">
+      <xs:choice>
+         <xs:element ref="tei:model.gLike"/>
+         <xs:group ref="tei:model.inter"/>
+         <xs:group ref="tei:model.phrase"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.limitedPhrase">
+      <xs:choice>
+         <xs:group ref="tei:model.emphLike"/>
+         <xs:group ref="tei:model.pPart.editorial"/>
+         <xs:group ref="tei:model.ptrLike"/>
+         <xs:group ref="tei:model.pPart.data"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="model.divLike" abstract="true">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.divTop"/>
+               <xs:group ref="tei:model.global"/>
+            </xs:choice>
+            <xs:choice minOccurs="0">
+               <xs:sequence maxOccurs="unbounded">
+                  <xs:element ref="tei:model.divLike"/>
+                  <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:sequence maxOccurs="unbounded">
+                     <xs:group ref="tei:model.common"/>
+                     <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+                  </xs:sequence>
+                  <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="tei:model.divLike"/>
+                     <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+                  </xs:sequence>
+               </xs:sequence>
+            </xs:choice>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.placement.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attributeGroup ref="tei:att.written.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="model.encodingDescPart" abstract="true"/>
+   <xs:element name="model.profileDescPart" abstract="true"/>
+   <xs:attributeGroup name="att.partials.attributes">
+      <xs:attributeGroup ref="tei:att.partials.attribute.extent"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.partials.attribute.extent">
+      <xs:attribute name="extent">
+         <xs:annotation>
+            <xs:documentation>indicates whether the pronunciation or orthography applies to all or part of a word.
+Suggested values include: 1] full (full form); 2] pref (prefix); 3] suff (suffix); 4] inf (infix); 5] part (partial)</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="full">
+                        <xs:annotation>
+                           <xs:documentation>(full form) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="pref">
+                        <xs:annotation>
+                           <xs:documentation>(prefix) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="suff">
+                        <xs:annotation>
+                           <xs:documentation>(suffix) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="inf">
+                        <xs:annotation>
+                           <xs:documentation>(infix) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="part">
+                        <xs:annotation>
+                           <xs:documentation>(partial) </xs:documentation>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="model.resource" abstract="true">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+            <xs:sequence minOccurs="0">
+               <xs:element ref="tei:front"/>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+            </xs:sequence>
+            <xs:element ref="tei:body"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+            <xs:sequence minOccurs="0">
+               <xs:element ref="tei:back"/>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+            </xs:sequence>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attributeGroup ref="tei:att.written.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.personal.attributes">
+      <xs:attributeGroup ref="tei:att.naming.attributes"/>
+      <xs:attributeGroup ref="tei:att.personal.attribute.full"/>
+      <xs:attributeGroup ref="tei:att.personal.attribute.sort"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.personal.attribute.full">
+      <xs:attribute name="full" default="yes">
+         <xs:annotation>
+            <xs:documentation>indicates whether the name component is given in full, as an abbreviation or simply as an initial.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="yes">
+                  <xs:annotation>
+                     <xs:documentation>(yes) the name component is spelled out in full.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="abb">
+                  <xs:annotation>
+                     <xs:documentation>(abbreviated) the name component is given in an abbreviated form.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="init">
+                  <xs:annotation>
+                     <xs:documentation>(initial letter) the name component is indicated only by one initial.</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.personal.attribute.sort">
+      <xs:attribute name="sort" type="xs:nonNegativeInteger">
+         <xs:annotation>
+            <xs:documentation>(sort) specifies the sort order of the name component in relation to others within the name.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="model.placeLike" abstract="true">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.headLike"/>
+            <xs:choice>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.pLike"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="tei:model.labelLike"/>
+                  <xs:group ref="tei:model.placeStateLike"/>
+                  <xs:element ref="tei:name"/>
+               </xs:choice>
+            </xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.noteLike"/>
+               <xs:group ref="tei:model.biblLike"/>
+               <xs:group ref="tei:model.ptrLike"/>
+               <xs:element ref="tei:idno"/>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:model.placeLike"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.calendarSystem.attributes">
+      <xs:attributeGroup ref="tei:att.calendarSystem.attribute.calendar"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.calendarSystem.attribute.calendar">
+      <xs:attribute name="calendar">
+         <xs:annotation>
+            <xs:documentation>indicates one or more systems or calendars to which the date represented by the content of this element belongs.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="p">
+      <xs:annotation>
+         <xs:documentation>(paragraph) marks paragraphs in prose. [3.1. Paragraphs 7.2.5. Speech Contents]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.paraContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.fragmentable.attributes"/>
+               <xs:attributeGroup ref="tei:att.written.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="hi">
+      <xs:annotation>
+         <xs:documentation>(highlighted) marks a word or phrase as graphically distinct from the surrounding text, for reasons concerning which no claim is made. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.paraContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.written.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="quote">
+      <xs:annotation>
+         <xs:documentation>(quotation) contains a phrase or passage attributed by the narrator or author to some agency external to the text. [3.3.3. Quotation 4.3.1. Grouped Texts]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexSpecialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.notated.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="cit">
+      <xs:annotation>
+         <xs:documentation>(cited quotation) contains a quotation from some other document, together with a bibliographic reference to its source. In a dictionary it may contain an example text with at least one occurrence of the word form, used in the sense being described, or a translation of the headword, or an example. [3.3.3. Quotation 4.3.1. Grouped Texts 10.3.5.1. Examples]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice maxOccurs="unbounded">
+            <xs:group ref="tei:model.quoteLike"/>
+            <xs:group ref="tei:model.biblLike"/>
+            <xs:group ref="tei:model.ptrLike"/>
+            <xs:group ref="tei:model.global"/>
+            <xs:group ref="tei:model.entryPart"/>
+            <xs:group ref="tei:model.segLike"/>
+            <xs:element ref="tei:lang"/>
+            <xs:element ref="tei:gloss"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type" use="required">
+            <xs:annotation>
+               <xs:documentation/>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="example">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="translation">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="translationEquivalent">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="etymon">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="cognate">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="cognateSet">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="desc">
+      <xs:annotation>
+         <xs:documentation>(description) contains a short description of the purpose, function, or use of its parent element, or when the parent is a documentation element, describes or defines the object being documented.  [23.4.1. Description of Components]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.limitedContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.translatable.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Suggested values include: 1] deprecationInfo (deprecation information)</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="deprecationInfo">
+                                 <xs:annotation>
+                                    <xs:documentation>(deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="gloss" type="tei:macro.phraseSeq">
+      <xs:annotation>
+         <xs:documentation>(gloss) identifies a phrase or word used to provide a gloss or definition for some other word or phrase. [3.4.1. Terms and Glosses 23.4.1. Description of Components]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="term">
+      <xs:annotation>
+         <xs:documentation>(term) contains a single-word, multi-word, or symbolic designation which is regarded as a technical term. [3.4.1. Terms and Glosses]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cReferencing.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.pointing.attributes"/>
+               <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="ruby">
+      <xs:annotation>
+         <xs:documentation>(ruby container) contains a passage of base text along with its associated ruby gloss(es). [3.4.2. Ruby Annotations]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="tei:rb"/>
+            <xs:element maxOccurs="unbounded" ref="tei:rt"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="rb">
+      <xs:annotation>
+         <xs:documentation>(ruby base) contains the base text annotated by a ruby gloss. [3.4.2. Ruby Annotations]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="rt">
+      <xs:annotation>
+         <xs:documentation>(ruby text) contains a ruby text, an annotation closely associated with a passage of the main text. [3.4.2. Ruby Annotations]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.transcriptional.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attribute name="target">
+                  <xs:annotation>
+                     <xs:documentation>supplies a pointer to the base being glossed by this ruby text.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="from">
+                  <xs:annotation>
+                     <xs:documentation>points to the starting point of the span of text being glossed by this ruby text.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="to">
+                  <xs:annotation>
+                     <xs:documentation>points to the ending point of the span of text being glossed.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="name">
+      <xs:annotation>
+         <xs:documentation>(name, proper noun) contains a proper noun or noun phrase. [3.6.1. Referring Strings]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.personal.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="email">
+      <xs:annotation>
+         <xs:documentation>(electronic mail address) contains an email address identifying a location to which email messages can be delivered. [3.6.2. Addresses]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="num">
+      <xs:annotation>
+         <xs:documentation>(number) contains a number, written in any form. [3.6.3. Numbers and
+Measures]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:attribute name="value">
+            <xs:annotation>
+               <xs:documentation>supplies the value of the number in standard form.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union memberTypes="xs:double xs:decimal">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="measure">
+      <xs:annotation>
+         <xs:documentation>(measure) contains a word or phrase referring to some quantity of an object or commodity, usually comprising a number, a unit, and a commodity name. [3.6.3. Numbers and
+Measures]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.measurement.attributes"/>
+         <xs:attributeGroup ref="tei:att.ranging.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type">
+            <xs:annotation>
+               <xs:documentation>specifies the type of measurement in any convenient typology.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="date">
+      <xs:annotation>
+         <xs:documentation>(date) contains a date in any format. [3.6.4. Dates and Times 2.2.4. Publication, Distribution, Licensing, etc. 2.6. The Revision Description 3.12.2.4. Imprint, Size of a Document, and Reprint Information 16.2.3. The Setting Description 14.4. Dates]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.phrase"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.calendarSystem.attributes"/>
+         <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.datable.attributes"/>
+         <xs:attributeGroup ref="tei:att.dimensions.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="abbr">
+      <xs:annotation>
+         <xs:documentation>(abbreviation) contains an abbreviation of any sort. [3.6.5. Abbreviations and Their Expansions]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>(type) allows the encoder to classify the abbreviation according to some convenient typology.
+Sample values include: 1] suspension (suspension); 2] contraction (contraction); 3] brevigraph; 4] superscription (superscription); 5] acronym (acronym); 6] title (title); 7] organization (organization); 8] geographic (geographic)</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="expan">
+      <xs:annotation>
+         <xs:documentation>(expansion) contains the expansion of an abbreviation. [3.6.5. Abbreviations and Their Expansions]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="ref">
+      <xs:annotation>
+         <xs:documentation>(reference) defines a reference to another location, possibly modified by additional text or comment. [3.7. Simple Links and Cross-References 17.1. Links]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+               <xs:attributeGroup ref="tei:att.notated.attributes"/>
+               <xs:attributeGroup ref="tei:att.scoped.attributes"/>
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cReferencing.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.internetMedia.attributes"/>
+               <xs:attributeGroup ref="tei:att.pointing.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type" use="required">
+                  <xs:annotation>
+                     <xs:documentation>
+Suggested values include: 1] entry; 2] sense; 3] bibliography; 4] example</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union memberTypes="xs:Name">
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="entry">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="sense">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="bibliography">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="example">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="list">
+      <xs:annotation>
+         <xs:documentation>(list) contains any sequence of items organized as a list. [3.8. Lists]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.divTop"/>
+               <xs:group ref="tei:model.global"/>
+               <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:desc"/>
+            </xs:choice>
+            <xs:sequence maxOccurs="unbounded">
+               <xs:element ref="tei:item"/>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+            </xs:sequence>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type">
+            <xs:annotation>
+               <xs:documentation>(type) describes the nature of the items in the list.
+Suggested values include: 1] gloss (gloss); 2] index (index); 3] instructions (instructions); 4] litany (litany); 5] syllogism (syllogism)</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="gloss"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="index">
+                           <xs:annotation>
+                              <xs:documentation>(index) each list item is an entry in an index such as the alphabetical topical index at the back of a print volume.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="instructions">
+                           <xs:annotation>
+                              <xs:documentation>(instructions) each list item is a step in a sequence of instructions, as in a recipe.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="litany">
+                           <xs:annotation>
+                              <xs:documentation>(litany) each list item is one of a sequence of petitions, supplications or invocations, typically in a religious ritual.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="syllogism">
+                           <xs:annotation>
+                              <xs:documentation>(syllogism) each list item is part of an argument consisting of two or more propositions and a final conclusion derived from them.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="item">
+      <xs:annotation>
+         <xs:documentation>(item) contains one component of a list. [3.8. Lists 2.6. The Revision Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.specialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="head">
+      <xs:annotation>
+         <xs:documentation>(heading) contains any type of heading, for example the title of a section, or the heading of a list, glossary, manuscript description, etc. [4.2.1. Headings and Trailers]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.phrase"/>
+            <xs:group ref="tei:model.inter"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.placement.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attributeGroup ref="tei:att.written.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="note">
+      <xs:annotation>
+         <xs:documentation>(note) contains a note or annotation. [3.9.1. Notes and Simple Annotation 2.2.6. The Notes Statement 3.12.2.8. Notes and Statement of Language 10.3.5.4. Notes within Entries]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexSpecialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.anchoring.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.placement.attributes"/>
+               <xs:attributeGroup ref="tei:att.pointing.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attributeGroup ref="tei:att.written.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="graphic">
+      <xs:annotation>
+         <xs:documentation>(graphic) indicates the location of a graphic or illustration, either forming part of a text, or providing an image of it. [3.10. Graphics and Other Non-textual Components 12.1. Digital Facsimiles]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.descLike"/>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.media.attributes"/>
+         <xs:attributeGroup ref="tei:att.resourced.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="analytic">
+      <xs:annotation>
+         <xs:documentation>(analytic level) contains bibliographic elements describing an item (e.g. an article or poem) published within a monograph or journal and not as an independent publication. [3.12.2.1. Analytic, Monographic, and Series Levels]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:author"/>
+            <xs:element ref="tei:editor"/>
+            <xs:element ref="tei:respStmt"/>
+            <xs:element ref="tei:title"/>
+            <xs:group ref="tei:model.ptrLike"/>
+            <xs:element ref="tei:date"/>
+            <xs:element ref="tei:idno"/>
+            <xs:element ref="tei:availability"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="monogr">
+      <xs:annotation>
+         <xs:documentation>(monographic level) contains bibliographic elements describing an item (e.g. a book or journal) published as an independent item (i.e. as a separate physical object). [3.12.2.1. Analytic, Monographic, and Series Levels]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0">
+               <xs:sequence>
+                  <xs:choice>
+                     <xs:element ref="tei:author"/>
+                     <xs:element ref="tei:editor"/>
+                     <xs:element ref="tei:respStmt"/>
+                  </xs:choice>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="tei:author"/>
+                     <xs:element ref="tei:editor"/>
+                     <xs:element ref="tei:respStmt"/>
+                  </xs:choice>
+                  <xs:element maxOccurs="unbounded" ref="tei:title"/>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:group ref="tei:model.ptrLike"/>
+                     <xs:element ref="tei:idno"/>
+                     <xs:element ref="tei:editor"/>
+                     <xs:element ref="tei:respStmt"/>
+                  </xs:choice>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:choice maxOccurs="unbounded">
+                     <xs:element ref="tei:title"/>
+                     <xs:group ref="tei:model.ptrLike"/>
+                     <xs:element ref="tei:idno"/>
+                  </xs:choice>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="tei:author"/>
+                     <xs:element ref="tei:editor"/>
+                     <xs:element ref="tei:respStmt"/>
+                  </xs:choice>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element ref="tei:authority"/>
+                  <xs:element ref="tei:idno"/>
+               </xs:sequence>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:availability"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.noteLike"/>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+               <xs:element ref="tei:edition"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="tei:idno"/>
+                  <xs:group ref="tei:model.ptrLike"/>
+                  <xs:element ref="tei:editor"/>
+                  <xs:element ref="tei:respStmt"/>
+               </xs:choice>
+            </xs:sequence>
+            <xs:element ref="tei:imprint"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:element ref="tei:imprint"/>
+               <xs:element ref="tei:extent"/>
+               <xs:element ref="tei:biblScope"/>
+            </xs:choice>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="author" substitutionGroup="tei:model.respLike">
+      <xs:annotation>
+         <xs:documentation>(author) in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="editor" substitutionGroup="tei:model.respLike">
+      <xs:annotation>
+         <xs:documentation>contains a secondary statement of responsibility for a bibliographic item, for example the name of an individual, institution or organization, (or of several such) acting as editor, compiler, translator, etc. [3.12.2.2. Titles, Authors, and Editors]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="respStmt" substitutionGroup="tei:model.respLike">
+      <xs:annotation>
+         <xs:documentation>(statement of responsibility) supplies a statement of responsibility for the intellectual content of a text, edition, recording, or series, where the specialized elements for authors, editors, etc. do not suffice or do not apply. May also be used to encode information about individuals or organizations which have played a role in the production or distribution of a bibliographic work. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.2. The Edition Statement 2.2.5. The Series Statement]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="tei:resp"/>
+                  <xs:group maxOccurs="unbounded" ref="tei:model.nameLike.agent"/>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:group maxOccurs="unbounded" ref="tei:model.nameLike.agent"/>
+                  <xs:element maxOccurs="unbounded" ref="tei:resp"/>
+               </xs:sequence>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:note"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="resp">
+      <xs:annotation>
+         <xs:documentation>(responsibility) contains a phrase describing the nature of a person's intellectual responsibility, or an organization's role in the production or distribution of a work. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.2. The Edition Statement 2.2.5. The Series Statement]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="title">
+      <xs:annotation>
+         <xs:documentation>(title) contains a title for any kind of work. [3.12.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.5. The Series Statement]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation/>
+                  </xs:annotation>
+               </xs:attribute>
+               <xs:attribute name="level">
+                  <xs:annotation>
+                     <xs:documentation>indicates the bibliographic level for a title, that is, whether it identifies an article, book, journal, series, or unpublished material.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="a">
+                           <xs:annotation>
+                              <xs:documentation>(analytic) the title applies to an analytic item, such as an article, poem, or other work published as part of a larger item.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="m">
+                           <xs:annotation>
+                              <xs:documentation>(monographic) the title applies to a monograph such as a book or other item considered to be a distinct publication, including single volumes of multi-volume works</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="j">
+                           <xs:annotation>
+                              <xs:documentation>(journal) the title applies to any serial or periodical publication such as a journal, magazine, or newspaper</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="s">
+                           <xs:annotation>
+                              <xs:documentation>(series) the title applies to a series of otherwise distinct publications such as a collection</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="u">
+                           <xs:annotation>
+                              <xs:documentation>(unpublished) the title applies to any unpublished material (including theses and dissertations unless published by a commercial press)</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="imprint">
+      <xs:annotation>
+         <xs:documentation>groups information relating to the publication or distribution of a bibliographic item. [3.12.2.4. Imprint, Size of a Document, and Reprint Information]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence maxOccurs="unbounded">
+            <xs:choice>
+               <xs:group ref="tei:model.imprintPart"/>
+               <xs:group ref="tei:model.dateLike"/>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:respStmt"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="publisher">
+      <xs:annotation>
+         <xs:documentation>(publisher) provides the name of the organization responsible for the publication or distribution of a bibliographic item. [3.12.2.4. Imprint, Size of a Document, and Reprint Information 2.2.4. Publication, Distribution, Licensing, etc.]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="biblScope">
+      <xs:annotation>
+         <xs:documentation>(scope of bibliographic reference) defines the scope of a bibliographic reference, for example as a list of page numbers, or a named subdivision of a larger work. [3.12.2.5. Scopes and Ranges in Bibliographic Citations]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.citing.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="citedRange">
+      <xs:annotation>
+         <xs:documentation>(cited range) defines the range of cited content, often represented by pages or other units. [3.12.2.5. Scopes and Ranges in Bibliographic Citations]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.citing.attributes"/>
+               <xs:attributeGroup ref="tei:att.pointing.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="pubPlace">
+      <xs:annotation>
+         <xs:documentation>(publication place) contains the name of the place where a bibliographic item was published. [3.12.2.4. Imprint, Size of a Document, and Reprint Information]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="bibl">
+      <xs:annotation>
+         <xs:documentation>(bibliographic citation) contains a loosely-structured bibliographic citation of which the sub-components may or may not be explicitly tagged. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 16.3.2. Declarable Elements]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.highlighted"/>
+            <xs:group ref="tei:model.pPart.data"/>
+            <xs:group ref="tei:model.pPart.edit"/>
+            <xs:group ref="tei:model.segLike"/>
+            <xs:group ref="tei:model.ptrLike"/>
+            <xs:group ref="tei:model.biblPart"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+         <xs:attributeGroup ref="tei:att.docStatus.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="biblStruct">
+      <xs:annotation>
+         <xs:documentation>(structured bibliographic citation) contains a structured bibliographic citation, in which only bibliographic sub-elements appear and in a specified order. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 16.3.2. Declarable Elements]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:analytic"/>
+            <xs:element maxOccurs="unbounded" ref="tei:monogr"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.noteLike"/>
+               <xs:group ref="tei:model.ptrLike"/>
+               <xs:element ref="tei:citedRange"/>
+            </xs:choice>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+         <xs:attributeGroup ref="tei:att.docStatus.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="listBibl">
+      <xs:annotation>
+         <xs:documentation>(citation list) contains a list of bibliographic citations of any kind. [3.12.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 16.3.2. Declarable Elements]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.headLike"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:desc"/>
+            <xs:group maxOccurs="unbounded" ref="tei:model.biblLike"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type" use="required">
+            <xs:annotation>
+               <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Suggested values include: 1] dictionaries; 2] corpora; 3] literature</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="dictionaries">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="corpora">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="literature">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.lexicographic.normalized.attributes">
+      <xs:attributeGroup ref="tei:att.lexicographic.normalized.attribute.norm"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.normalized.attribute.orig"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.normalized.attribute.norm">
+      <xs:attribute name="norm" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(normalized) provides the normalized/standardized form of information present in the source text in a non-normalized form.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.normalized.attribute.orig">
+      <xs:attribute name="orig" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(original) gives the original string or is the empty string when the element does not appear in the source text.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.linguistic.attributes">
+      <xs:attributeGroup ref="tei:att.lexicographic.normalized.attributes"/>
+      <xs:attributeGroup ref="tei:att.linguistic.attribute.lemma"/>
+      <xs:attributeGroup ref="tei:att.linguistic.attribute.lemmaRef"/>
+      <xs:attributeGroup ref="tei:att.linguistic.attribute.pos"/>
+      <xs:attributeGroup ref="tei:att.linguistic.attribute.msd"/>
+      <xs:attributeGroup ref="tei:att.linguistic.attribute.join"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.linguistic.attribute.lemma">
+      <xs:attribute name="lemma" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>provides a lemma (base form) for the word, typically uninflected and serving both as an identifier (e.g. in dictionary contexts, as a headword), and as a basis for potential inflections.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.linguistic.attribute.lemmaRef">
+      <xs:attribute name="lemmaRef">
+         <xs:annotation>
+            <xs:documentation>provides a pointer to a definition of the lemma for the word, for example in an online lexicon.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.linguistic.attribute.pos">
+      <xs:attribute name="pos" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(part of speech) indicates the part of speech assigned to a token (i.e. information on whether it is a noun, adjective, or verb), usually according to some official reference vocabulary (e.g. for German: STTS, for English: CLAWS, for Polish: NKJP, etc.).</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.linguistic.attribute.msd">
+      <xs:attribute name="msd" type="xs:string"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.linguistic.attribute.join">
+      <xs:attribute name="join">
+         <xs:annotation>
+            <xs:documentation>when present, provides information on whether the token in question is adjacent to another, and if so, on which side.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="no">
+                  <xs:annotation>
+                     <xs:documentation>the token is not adjacent to another</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="left">
+                  <xs:annotation>
+                     <xs:documentation>there is no whitespace on the left side of the token</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="right">
+                  <xs:annotation>
+                     <xs:documentation>there is no whitespace on the right side of the token</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="both">
+                  <xs:annotation>
+                     <xs:documentation>there is no whitespace on either side of the token</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+               <xs:enumeration value="overlap">
+                  <xs:annotation>
+                     <xs:documentation>the token overlaps with another; other devices (specifying the extent and the area of overlap) are needed to more precisely locate this token in the character stream</xs:documentation>
+                  </xs:annotation>
+               </xs:enumeration>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.analytic.attributes">
+      <xs:attributeGroup ref="tei:att.global.analytic.attribute.ana"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.analytic.attribute.ana">
+      <xs:attribute name="ana">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="c">
+      <xs:annotation>
+         <xs:documentation>(character) represents a character. [18.1. Linguistic Segment Categories]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.xtext">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.notated.attributes"/>
+               <xs:attributeGroup ref="tei:att.segLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="pc">
+      <xs:annotation>
+         <xs:documentation>(punctuation character) contains a character or string of characters regarded as constituting a single punctuation mark. [18.1.2. Below the Word Level 18.4.2. Lightweight Linguistic Annotation]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:element ref="tei:c"/>
+            <xs:group ref="tei:model.pPart.edit"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.linguistic.attributes"/>
+         <xs:attributeGroup ref="tei:att.segLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attribute name="force">
+            <xs:annotation>
+               <xs:documentation>indicates the extent to which this punctuation mark conventionally separates words or phrases.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="strong">
+                     <xs:annotation>
+                        <xs:documentation>the punctuation mark is a word separator</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="weak">
+                     <xs:annotation>
+                        <xs:documentation>the punctuation mark is not a word separator</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="inter">
+                     <xs:annotation>
+                        <xs:documentation>the punctuation mark may or may not be a word separator</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="unit">
+            <xs:annotation>
+               <xs:documentation>provides a name for the kind of unit delimited by this punctuation mark.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="pre" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation>indicates whether this punctuation mark precedes or follows the unit it delimits.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.gaijiProp.attributes">
+      <xs:attributeGroup ref="tei:att.datable.attributes"/>
+      <xs:attributeGroup ref="tei:att.gaijiProp.attribute.name"/>
+      <xs:attributeGroup ref="tei:att.gaijiProp.attribute.value"/>
+      <xs:attributeGroup ref="tei:att.gaijiProp.attribute.version"/>
+      <xs:attributeGroup ref="tei:att.gaijiProp.attribute.scheme"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.gaijiProp.attribute.name">
+      <xs:attribute name="name" use="required" type="xs:NCName">
+         <xs:annotation>
+            <xs:documentation>provides the name of the character or glyph property being defined.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.gaijiProp.attribute.value">
+      <xs:attribute name="value" use="required" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>provides the value of the character or glyph property being defined.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.gaijiProp.attribute.version">
+      <xs:attribute name="version">
+         <xs:annotation>
+            <xs:documentation>specifies the version number of the Unicode Standard in which this property name is defined.
+Suggested values include: 1] 1.0.1; 2] 1.1; 3] 2.0; 4] 2.1; 5] 3.0; 6] 3.1; 7] 3.2; 8] 4.0; 9] 4.1; 10] 5.0; 11] 5.1; 12] 5.2; 13] 6.0; 14] 6.1; 15] 6.2; 16] 6.3; 17] 7.0; 18] 8.0; 19] 9.0; 20] 10.0; 21] 11.0; 22] 12.0; 23] 12.1; 24] 13.0; 25] 14.0; 26] 15.0; 27] unassigned</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="1.0.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="1.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="2.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="2.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="3.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="3.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="3.2">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="4.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="4.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="5.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="5.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="5.2">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="6.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="6.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="6.2">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="6.3">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="7.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="8.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="9.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="10.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="11.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="12.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="12.1">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="13.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="14.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="15.0">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="unassigned">
+                        <xs:annotation>
+                           <xs:documentation/>
+                        </xs:annotation>
+                     </xs:enumeration>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.gaijiProp.attribute.scheme">
+      <xs:attribute name="scheme" default="Unicode">
+         <xs:annotation>
+            <xs:documentation>supplies the name of the character set system from which this property is drawn.
+Sample values include: 1] Unicode (Unicode); 2] Bridwell (E. Nelson Bridwell); 3] Brewer (Georg Brewer); 4] Doyle (Darren Doyle); 5] Schreyer (Christine Schreyer)</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:pattern value="[^\p{C}\p{Z}]+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="g" substitutionGroup="tei:model.gLike">
+      <xs:annotation>
+         <xs:documentation>(character or glyph) represents a glyph, or a non-standard character. [5. Characters, Glyphs, and Writing Modes]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="charDecl" substitutionGroup="tei:model.encodingDescPart">
+      <xs:annotation>
+         <xs:documentation>(character declarations) provides information about nonstandard characters and glyphs. [5.2. Markup Constructs for Representation of Characters and Glyphs]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" ref="tei:desc"/>
+            <xs:choice maxOccurs="unbounded">
+               <xs:element ref="tei:char"/>
+               <xs:element ref="tei:glyph"/>
+            </xs:choice>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="char">
+      <xs:annotation>
+         <xs:documentation>(character) provides descriptive information about a character. [5.2. Markup Constructs for Representation of Characters and Glyphs]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:unicodeProp"/>
+            <xs:element ref="tei:unihanProp"/>
+            <xs:element ref="tei:localProp"/>
+            <xs:element ref="tei:mapping"/>
+            <xs:element ref="tei:figure"/>
+            <xs:group ref="tei:model.graphicLike"/>
+            <xs:group ref="tei:model.noteLike"/>
+            <xs:group ref="tei:model.descLike"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="glyph">
+      <xs:annotation>
+         <xs:documentation>(character glyph) provides descriptive information about a character glyph. [5.2. Markup Constructs for Representation of Characters and Glyphs]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:unicodeProp"/>
+            <xs:element ref="tei:unihanProp"/>
+            <xs:element ref="tei:localProp"/>
+            <xs:element ref="tei:mapping"/>
+            <xs:element ref="tei:figure"/>
+            <xs:group ref="tei:model.graphicLike"/>
+            <xs:group ref="tei:model.noteLike"/>
+            <xs:group ref="tei:model.descLike"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="localProp">
+      <xs:annotation>
+         <xs:documentation>(locally defined property) provides a locally defined character (or glyph) property. [5.2.1. Character Properties]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.gaijiProp.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="mapping">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.xtext">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="unihanProp">
+      <xs:annotation>
+         <xs:documentation>(unihan property) holds the name and value of a normative or informative Unihan character (or glyph) property as part of its attributes. [5.2.1. Character Properties]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.gaijiProp.attribute.version"/>
+         <xs:attributeGroup ref="tei:att.gaijiProp.attribute.scheme"/>
+         <xs:attributeGroup ref="tei:att.datable.attribute.period"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.when-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.notBefore-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.notAfter-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.from-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.to-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.datingPoint"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.datingMethod"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.when-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.notBefore-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.notAfter-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.from-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.to-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.when"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.notBefore"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.notAfter"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.from"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.to"/>
+         <xs:attribute name="name" use="required">
+            <xs:annotation>
+               <xs:documentation>specifies the normalized name of a unicode han database (Unihan) property.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="kZVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kAccountingNumeric">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kBigFive">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCCCII">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCNS1986">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCNS1992">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCangjie">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCantonese">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCheungBauer">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCheungBauerIndex">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCihaiT">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCompatibilityVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCowles">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kDaeJaweon">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kDefinition">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kEACC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kFenn">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kFennIndex">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kFourCornerCode">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kFrequency">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGB0">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGB1">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGB3">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGB5">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGB7">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGB8">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGSR">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kGradeLevel">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHDZRadBreak">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHKGlyph">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHKSCS">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHanYu">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHangul">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHanyuPinlu">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kHanyuPinyin">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIBMJapan">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIICore">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRGDaeJaweon">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRGDaiKanwaZiten">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRGHanyuDaZidian">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRGKangXi">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_GSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_HSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_JSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_KPSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_KSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_MSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_TSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_USource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_VSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJIS0213">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJa">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJapaneseKun">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJapaneseOn">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJinmeiyoKanji">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJis0">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJis1">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kJoyoKanji">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKPS0">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKPS1">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKSC0">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKSC1">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKangXi">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKarlgren">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKorean">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKoreanEducationHanja">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kKoreanName">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kLau">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kMainlandTelegraph">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kMandarin">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kMatthews">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kMeyerWempe">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kMorohashi">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kNelson">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kOtherNumeric">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kPhonetic">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kPrimaryNumeric">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kPseudoGB1">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSAdobe_Japan1_6">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSJapanese">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSKanWa">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSKangXi">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSKorean">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSUnicode">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kSBGY">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kSemanticVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kSimplifiedVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kSpecializedSemanticVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kTGH">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kTaiwanTelegraph">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kTang">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kTotalStrokes">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kTraditionalVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kVietnamese">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kXHC1983">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kXerox">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="value" use="required">
+            <xs:annotation>
+               <xs:documentation>specifies the value of a named Unihan property</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="unicodeProp">
+      <xs:annotation>
+         <xs:documentation>(unicode property) provides a Unicode property for a character (or glyph). [5.2.1. Character Properties]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.gaijiProp.attribute.version"/>
+         <xs:attributeGroup ref="tei:att.gaijiProp.attribute.scheme"/>
+         <xs:attributeGroup ref="tei:att.datable.attribute.period"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.when-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.notBefore-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.notAfter-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.from-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.to-custom"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.datingPoint"/>
+         <xs:attributeGroup ref="tei:att.datable.custom.attribute.datingMethod"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.when-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.notBefore-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.notAfter-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.from-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.iso.attribute.to-iso"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.when"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.notBefore"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.notAfter"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.from"/>
+         <xs:attributeGroup ref="tei:att.datable.w3c.attribute.to"/>
+         <xs:attribute name="name" use="required">
+            <xs:annotation>
+               <xs:documentation>specifies the normalized name of a Unicode property.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="Age">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="AHex">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Alpha">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Alphabetic">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ASCII_Hex_Digit">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="bc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_C">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_Class">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_Control">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_M">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_Mirrored">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_Mirroring_Glyph">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_Paired_Bracket">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Bidi_Paired_Bracket_Type">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="blk">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Block">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="bmg">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="bpb">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="bpt">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Canonical_Combining_Class">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Case_Folding">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Case_Ignorable">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Cased">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ccc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CE">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="cf">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Changes_When_Casefolded">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Changes_When_Casemapped">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Changes_When_Lowercased">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Changes_When_NFKC_Casefolded">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Changes_When_Titlecased">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Changes_When_Uppercased">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CI">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Comp_Ex">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Composition_Exclusion">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CWCF">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CWCM">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CWKCF">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CWL">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CWT">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="CWU">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Dash">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Decomposition_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Decomposition_Type">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Default_Ignorable_Code_Point">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Dep">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Deprecated">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="DI">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Dia">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Diacritic">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="dm">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="dt">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ea">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="East_Asian_Width">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="EqUIdeo">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Equivalent_Unified_Ideograph">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Expands_On_NFC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Expands_On_NFD">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Expands_On_NFKC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Expands_On_NFKD">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Ext">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Extender">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="FC_NFKC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="FC_NFKC_Closure">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Full_Composition_Exclusion">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="gc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="GCB">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="General_Category">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Gr_Base">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Gr_Ext">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Gr_Link">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Grapheme_Base">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Grapheme_Cluster_Break">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Grapheme_Extend">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Grapheme_Link">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Hangul_Syllable_Type">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Hex">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Hex_Digit">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="hst">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Hyphen">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ID_Continue">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ID_Start">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="IDC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Ideo">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Ideographic">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="IDS">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="IDS_Binary_Operator">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="IDS_Trinary_Operator">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="IDSB">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="IDST">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Indic_Positional_Category">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Indic_Syllabic_Category">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="InPC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="InSC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="isc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ISO_Comment">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Jamo_Short_Name">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="jg">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Join_C">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Join_Control">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Joining_Group">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Joining_Type">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="JSN">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="jt">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kAccountingNumeric">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kCompatibilityVariant">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIICore">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_GSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_HSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_JSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_KPSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_KSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_MSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_TSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_USource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kIRG_VSource">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kOtherNumeric">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kPrimaryNumeric">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="kRSUnicode">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="lb">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="lc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Line_Break">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="LOE">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Logical_Order_Exception">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Lower">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Lowercase">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Lowercase_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Math">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="na">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="na1">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Name">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Name_Alias">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NChar">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFC_QC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFC_Quick_Check">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFD_QC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFD_Quick_Check">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFKC_Casefold">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFKC_CF">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFKC_QC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFKC_Quick_Check">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFKD_QC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="NFKD_Quick_Check">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Noncharacter_Code_Point">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="nt">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Numeric_Type">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Numeric_Value">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="nv">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OAlpha">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="ODI">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OGr_Ext">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OIDC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OIDS">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OLower">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OMath">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_Alphabetic">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_Default_Ignorable_Code_Point">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_Grapheme_Extend">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_ID_Continue">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_ID_Start">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_Lowercase">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_Math">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Other_Uppercase">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="OUpper">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Pat_Syn">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Pat_WS">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Pattern_Syntax">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Pattern_White_Space">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="PCM">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Prepended_Concatenation_Mark">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="QMark">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Quotation_Mark">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Radical">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Regional_Indicator">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="RI">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="SB">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="sc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="scf">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Script">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Script_Extensions">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="scx">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="SD">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Sentence_Break">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Sentence_Terminal">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Simple_Case_Folding">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Simple_Lowercase_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Simple_Titlecase_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Simple_Uppercase_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="slc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Soft_Dotted">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="stc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="STerm">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="suc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="tc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Term">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Terminal_Punctuation">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Titlecase_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="uc">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="UIdeo">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Unicode_1_Name">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Unified_Ideograph">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Upper">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Uppercase">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Uppercase_Mapping">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Variation_Selector">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Vertical_Orientation">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="vo">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="VS">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="WB">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="White_Space">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="Word_Break">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="WSpace">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XID_Continue">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XID_Start">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XIDC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XIDS">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XO_NFC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XO_NFD">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XO_NFKC">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="XO_NFKD">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="value" use="required" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>specifies the value of a named Unicode property.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="settingDesc" substitutionGroup="tei:model.profileDescPart">
+      <xs:annotation>
+         <xs:documentation>(setting description) describes the setting or settings within which a language interaction takes place, or other places otherwise referred to in a text, edition, or metadata. [16.2. Contextual Information 2.4. The Profile Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:element maxOccurs="unbounded" ref="tei:model.placeLike"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="channel">
+      <xs:annotation>
+         <xs:documentation>(primary channel) describes the medium or channel by which a text is delivered or experienced. For a written text, this might be print, manuscript, email, etc.; for a spoken one, radio, telephone, face-to-face, etc. [16.2.1. The Text Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attribute name="mode" default="x">
+                  <xs:annotation>
+                     <xs:documentation>specifies the mode of this channel with respect to speech and writing.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="s">
+                           <xs:annotation>
+                              <xs:documentation>(spoken) </xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="w">
+                           <xs:annotation>
+                              <xs:documentation>(written) </xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="sw">
+                           <xs:annotation>
+                              <xs:documentation>(spoken to be written) e.g. dictation</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="ws">
+                           <xs:annotation>
+                              <xs:documentation>(written to be spoken) e.g. a script</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="m">
+                           <xs:annotation>
+                              <xs:documentation>(mixed) </xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="x">
+                           <xs:annotation>
+                              <xs:documentation>(unknown or inapplicable) </xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="domain">
+      <xs:annotation>
+         <xs:documentation>(domain of use) describes the most important social context in which the text was realized or for which it is intended, for example private vs. public, education, religion, etc. [16.2.1. The Text Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>categorizes the domain of use.
+Sample values include: 1] art; 2] domestic; 3] religious; 4] business; 5] education (education); 6] govt (government); 7] public</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="interaction">
+      <xs:annotation>
+         <xs:documentation>(interaction) describes the extent, cardinality and nature of any interaction among those producing and experiencing the text, for example in the form of response or interjection, commentary, etc. [16.2.1. The Text Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>specifies the degree of interaction between active and passive participants in the text.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="none">
+                           <xs:annotation>
+                              <xs:documentation>no interaction of any kind, e.g. a monologue</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="partial">
+                           <xs:annotation>
+                              <xs:documentation>some degree of interaction, e.g. a monologue with set responses</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="complete">
+                           <xs:annotation>
+                              <xs:documentation>complete interaction, e.g. a face to face conversation</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="inapplicable">
+                           <xs:annotation>
+                              <xs:documentation>this parameter is inappropriate or inapplicable in this case</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="active">
+                  <xs:annotation>
+                     <xs:documentation>specifies the number of active participants (or addressors) producing parts of the text.
+Suggested values include: 1] singular; 2] plural; 3] corporate; 4] unknown</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="singular">
+                                 <xs:annotation>
+                                    <xs:documentation>a single addressor</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="plural">
+                                 <xs:annotation>
+                                    <xs:documentation>many addressors</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="corporate">
+                                 <xs:annotation>
+                                    <xs:documentation>a corporate addressor</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="unknown">
+                                 <xs:annotation>
+                                    <xs:documentation>number of addressors unknown or unspecifiable</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="passive">
+                  <xs:annotation>
+                     <xs:documentation>specifies the number of passive participants (or addressees) to whom a text is directed or in whose presence it is created or performed.
+Suggested values include: 1] self; 2] single; 3] many; 4] group; 5] world</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="self">
+                                 <xs:annotation>
+                                    <xs:documentation>text is addressed to the originator e.g. a diary</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="single">
+                                 <xs:annotation>
+                                    <xs:documentation>text is addressed to one other person e.g. a personal letter</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="many">
+                                 <xs:annotation>
+                                    <xs:documentation>text is addressed to a countable number of others e.g. a conversation in which all participants are identified</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="group">
+                                 <xs:annotation>
+                                    <xs:documentation>text is addressed to an undefined but fixed number of participants e.g. a lecture</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="world">
+                                 <xs:annotation>
+                                    <xs:documentation>text is addressed to an undefined and indeterminately large number e.g. a published book</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="purpose">
+      <xs:annotation>
+         <xs:documentation>characterizes a single purpose or communicative function of the text. [16.2.1. The Text Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>specifies a particular kind of purpose.
+Suggested values include: 1] persuade; 2] express; 3] inform; 4] entertain</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="persuade">
+                                 <xs:annotation>
+                                    <xs:documentation>didactic, advertising, propaganda, etc.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="express">
+                                 <xs:annotation>
+                                    <xs:documentation>self expression, confessional, etc.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="inform">
+                                 <xs:annotation>
+                                    <xs:documentation>convey information, educate, etc.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="entertain">
+                                 <xs:annotation>
+                                    <xs:documentation>amuse, entertain, etc.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="degree">
+                  <xs:annotation>
+                     <xs:documentation>specifies the extent to which this purpose predominates.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="high">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="medium">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="low">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="unknown">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="model.entryLike" abstract="true">
+      <xs:complexType>
+         <xs:choice maxOccurs="unbounded">
+            <xs:element ref="tei:sense"/>
+            <xs:element ref="tei:pc"/>
+            <xs:group ref="tei:model.entryPart.top"/>
+            <xs:group ref="tei:model.global"/>
+            <xs:group ref="tei:model.ptrLike"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attribute.n"/>
+         <xs:attributeGroup ref="tei:att.global.attribute.xmlbase"/>
+         <xs:attributeGroup ref="tei:att.global.analytic.attribute.ana"/>
+         <xs:attributeGroup ref="tei:att.global.change.attribute.change"/>
+         <xs:attributeGroup ref="tei:att.global.facs.attribute.facs"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.corresp"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.synch"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.sameAs"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.copyOf"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.next"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.prev"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.exclude"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.select"/>
+         <xs:attributeGroup ref="tei:att.global.rendition.attribute.rend"/>
+         <xs:attributeGroup ref="tei:att.global.rendition.attribute.style"/>
+         <xs:attributeGroup ref="tei:att.global.rendition.attribute.rendition"/>
+         <xs:attributeGroup ref="tei:att.global.responsibility.attribute.cert"/>
+         <xs:attributeGroup ref="tei:att.global.responsibility.attribute.resp"/>
+         <xs:attributeGroup ref="tei:att.global.source.attribute.source"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attribute ref="xml:id" use="required"/>
+         <xs:attribute ref="xml:lang" use="required"/>
+         <xs:attribute name="type" use="required">
+            <xs:annotation>
+               <xs:documentation>
+Suggested values include: 1] mainEntry; 2] wordFamily; 3] homonymicEntry; 4] relatedEntry</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union memberTypes="xs:Name">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="mainEntry">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="wordFamily">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="homonymicEntry">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="relatedEntry">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.lexicographic.attributes">
+      <xs:attributeGroup ref="tei:att.datcat.attributes"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.normalized.attributes"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.attribute.expand"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.attribute.split"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.attribute.value"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.attribute.location"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.attribute.mergedIn"/>
+      <xs:attributeGroup ref="tei:att.lexicographic.attribute.opt"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.attribute.expand">
+      <xs:attribute name="expand" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(expand) gives an expanded form of information presented more concisely in the dictionary.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.attribute.split">
+      <xs:attribute name="split" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(split) gives the list of split values for a merged form.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.attribute.value">
+      <xs:attribute name="value" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>(value) gives a value which lacks any realization in the printed source text.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.attribute.location">
+      <xs:attribute name="location">
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.attribute.mergedIn">
+      <xs:attribute name="mergedIn">
+         <xs:annotation>
+            <xs:documentation>(merged into) gives a reference to another element, where the original appears as a merged form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.lexicographic.attribute.opt">
+      <xs:attribute name="opt" default="false" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>(optional) indicates whether the element is optional or not.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="model.morphLike" abstract="true">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type" use="required">
+                  <xs:annotation>
+                     <xs:documentation>
+Suggested values include: 1] pos; 2] aspect; 3] case; 4] construction; 5] degree; 6] gender; 7] inflectionType; 8] mood; 9] number; 10] tense; 11] valency; 12] collocate</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union memberTypes="xs:Name">
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="pos">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="aspect">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="case">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="construction">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="degree">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="gender">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="inflectionType">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="mood">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="number">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="tense">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="valency">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="collocate">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="model.lexicalRefinement">
+      <xs:choice>
+         <xs:element ref="tei:gramGrp"/>
+         <xs:element ref="tei:usg"/>
+         <xs:element ref="tei:lbl"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="entry" substitutionGroup="tei:model.entryLike">
+      <xs:annotation>
+         <xs:documentation>(entry) contains a single structured entry in any kind of lexical resource, such as a dictionary or lexicon. [10.1. Dictionary Body and Overall Structure 10.2. The Structure of Dictionary Entries]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="sense">
+      <xs:annotation>
+         <xs:documentation>groups together all information relating to one word sense in a dictionary entry, for example definitions, examples, and translation equivalents. [10.2. The Structure of Dictionary Entries]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.sensePart"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attribute.n"/>
+         <xs:attributeGroup ref="tei:att.global.attribute.xmllang"/>
+         <xs:attributeGroup ref="tei:att.global.attribute.xmlbase"/>
+         <xs:attributeGroup ref="tei:att.global.analytic.attribute.ana"/>
+         <xs:attributeGroup ref="tei:att.global.change.attribute.change"/>
+         <xs:attributeGroup ref="tei:att.global.facs.attribute.facs"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.corresp"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.synch"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.sameAs"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.copyOf"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.next"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.prev"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.exclude"/>
+         <xs:attributeGroup ref="tei:att.global.linking.attribute.select"/>
+         <xs:attributeGroup ref="tei:att.global.rendition.attribute.rend"/>
+         <xs:attributeGroup ref="tei:att.global.rendition.attribute.style"/>
+         <xs:attributeGroup ref="tei:att.global.rendition.attribute.rendition"/>
+         <xs:attributeGroup ref="tei:att.global.responsibility.attribute.cert"/>
+         <xs:attributeGroup ref="tei:att.global.responsibility.attribute.resp"/>
+         <xs:attributeGroup ref="tei:att.global.source.attribute.source"/>
+         <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+         <xs:attribute ref="xml:id" use="required"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="form">
+      <xs:annotation>
+         <xs:documentation>(form information group) groups all the information on the written and spoken forms of one headword. [10.3.1. Information on Written and Spoken Forms]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.lexPhrase"/>
+            <xs:group ref="tei:model.lexInter"/>
+            <xs:group ref="tei:model.lexFormPart"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type">
+            <xs:annotation>
+               <xs:documentation>classifies form as simple, compound, etc.
+Suggested values include: 1] simple; 2] lemma; 3] variant; 4] compound; 5] derivative; 6] inflected; 7] phrase</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="simple">
+                           <xs:annotation>
+                              <xs:documentation>single free lexical item</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="lemma">
+                           <xs:annotation>
+                              <xs:documentation>the headword itself</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="variant">
+                           <xs:annotation>
+                              <xs:documentation>a variant form</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="compound">
+                           <xs:annotation>
+                              <xs:documentation>word formed from simple lexical items</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="derivative">
+                           <xs:annotation>
+                              <xs:documentation>word derived from headword</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="inflected">
+                           <xs:annotation>
+                              <xs:documentation>word in other than usual dictionary form</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="phrase">
+                           <xs:annotation>
+                              <xs:documentation>multiple-word lexical item</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="orth">
+      <xs:annotation>
+         <xs:documentation>(orthographic form) gives the orthographic form of a dictionary headword. [10.3.1. Information on Written and Spoken Forms]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.datable.w3c.attributes"/>
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+               <xs:attributeGroup ref="tei:att.notated.attributes"/>
+               <xs:attributeGroup ref="tei:att.partials.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>gives the type of spelling.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="pron">
+      <xs:annotation>
+         <xs:documentation>(pronunciation) contains the pronunciation(s) of the word. [10.3.1. Information on Written and Spoken Forms]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.datable.w3c.attributes"/>
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+               <xs:attributeGroup ref="tei:att.notated.attributes"/>
+               <xs:attributeGroup ref="tei:att.partials.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="hyph" type="tei:macro.lexParaContent">
+      <xs:annotation>
+         <xs:documentation>(hyphenation) contains a hyphenated form of a dictionary headword, or hyphenation information in some other form. [10.3.1. Information on Written and Spoken Forms]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="syll" type="tei:macro.lexParaContent">
+      <xs:annotation>
+         <xs:documentation>(syllabification) contains the syllabification of the headword. [10.3.1. Information on Written and Spoken Forms]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="stress" type="tei:macro.lexParaContent">
+      <xs:annotation>
+         <xs:documentation>(stress) contains the stress pattern for a dictionary headword, if given separately. [10.3.1. Information on Written and Spoken Forms]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="gram" substitutionGroup="tei:model.morphLike">
+      <xs:annotation>
+         <xs:documentation>(grammatical information) within an entry in a dictionary or a terminological data file, contains grammatical information relating to a term, word, or form. [10.3.2. Grammatical Information]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="gramGrp">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.lexPhrase"/>
+            <xs:group ref="tei:model.lexInter"/>
+            <xs:element ref="tei:gramGrp"/>
+            <xs:element ref="tei:usg"/>
+            <xs:element ref="tei:model.morphLike"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="def">
+      <xs:annotation>
+         <xs:documentation>(definition) contains definition text in a dictionary entry. [10.3.3.1. Definitions]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexSpecialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="etym">
+      <xs:annotation>
+         <xs:documentation>(etymology) encloses the etymological information in a dictionary entry. [10.3.4. Etymological Information]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.global"/>
+            <xs:group ref="tei:model.lexInter"/>
+            <xs:group ref="tei:model.lexPhrase"/>
+            <xs:group ref="tei:model.descLike"/>
+            <xs:element ref="tei:def"/>
+            <xs:element ref="tei:etym"/>
+            <xs:element ref="tei:gramGrp"/>
+            <xs:element ref="tei:lbl"/>
+            <xs:element ref="tei:usg"/>
+            <xs:element ref="tei:xr"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type">
+            <xs:annotation>
+               <xs:documentation/>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="borrowing">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="inheritance">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="metaphor">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="metonymy">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="compounding">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="grammaticalization">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="derivation">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="lang">
+      <xs:annotation>
+         <xs:documentation>(language name) contains the name of a language mentioned in etymological or other linguistic discussion. [10.3.4. Etymological Information]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="usg">
+      <xs:annotation>
+         <xs:documentation>(usage) contains usage information in a dictionary entry. [10.3.5.2. Usage Information and Other Labels]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type" use="required">
+                  <xs:annotation>
+                     <xs:documentation/>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="temporal">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the use of a given lexical unit on a scale from old to new</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="geographic">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the place or region where a lexical unit is mainly used</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="socioCultural">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the use of a given lexical unit by particular social groups and/or in certain types of communicative situations depending on their level of formality</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="domain">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the specialized field of knowledge in which a lexical unit is mainly used</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="frequency">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the relative rate of occurrence of a lexical unit in a given textual context</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="attitude">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the speaker’s subjective point of view, positive or negative, regarding the object referred to by a given lexical unit</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="normativity">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the use of a given lexical unit which is in some aspect considered to be non-standard or incorrect </xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="meaningType">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies a semantic extension of the sense of a given lexical unit</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="textType">
+                           <xs:annotation>
+                              <xs:documentation>marker which identifies the typical use of a lexical unit in a particular discourse type or genre</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="hint">
+                           <xs:annotation>
+                              <xs:documentation>marker which cannot be classified otherwise</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="lbl">
+      <xs:annotation>
+         <xs:documentation>(label) contains a label for a form, example, translation, or other piece of information, e.g. abbreviation for, contraction of, literally, approximately, synonyms:, etc. [10.3.1. Information on Written and Spoken Forms 10.3.3.2. Translation Equivalents 10.3.5.3. Cross-References to Other Entries]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>classifies the label using any convenient typology.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="xr">
+      <xs:annotation>
+         <xs:documentation>(cross-reference phrase) contains a phrase, sentence, or icon referring the reader to some other location in this or another text. [10.3.5.3. Cross-References to Other Entries]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:group ref="tei:model.lexPhrase"/>
+            <xs:group ref="tei:model.lexInter"/>
+            <xs:element ref="tei:usg"/>
+            <xs:element ref="tei:lbl"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.lexicographic.attributes"/>
+         <xs:attribute name="type" use="required">
+            <xs:annotation>
+               <xs:documentation/>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="synonymy">
+                     <xs:annotation>
+                        <xs:documentation>Relation between two lexical units X and Y which are syntactically identical and have the property that any declarative sentence S containing X has equivalent truth conditions to another sentence S’ which is identical to S, except that X is replaced by Y. (Adapted from Cruse (1986).)</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="hyponymy">
+                     <xs:annotation>
+                        <xs:documentation>Relation between lexical units X and Y characterised by the property that the sentence ‘This is a(n) X’ entails, but is not entailed by the sentence ‘This is a(n) Y’. (Adapted from Cruse (1986).) </xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="hypernymy">
+                     <xs:annotation>
+                        <xs:documentation>Relation between lexical heads X and Y characterised by the property that the sentence ‘This is a(n) Y’ entails, but is not entailed by the sentence ‘This is a(n) X’. (Adapted from Cruse (1986).) </xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="meronymy">
+                     <xs:annotation>
+                        <xs:documentation>An inclusion relation between lexical heads X and Y which reflect a potential part-whole relation between their referents in discourse. (Adapted from Cruse (2011, p. 140).)</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="antonymy">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="related">
+                     <xs:annotation>
+                        <xs:documentation>The default reference to another lexical unit when no additional information is available.</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="subtype">
+            <xs:annotation>
+               <xs:documentation/>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="figure">
+      <xs:annotation>
+         <xs:documentation>(figure) groups elements representing or containing graphic information such as an illustration, formula, or figure. [15.4. Specific Elements for Graphic Images]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="tei:model.headLike"/>
+            <xs:group ref="tei:model.common"/>
+            <xs:element ref="tei:figDesc"/>
+            <xs:group ref="tei:model.graphicLike"/>
+            <xs:group ref="tei:model.global"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.placement.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attributeGroup ref="tei:att.written.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="figDesc">
+      <xs:annotation>
+         <xs:documentation>(description of figure) contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it. [15.4. Specific Elements for Graphic Images]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.limitedContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="teiHeader">
+      <xs:annotation>
+         <xs:documentation>(TEI header) supplies descriptive and declarative metadata associated with a digital resource or set of resources. [2.1.1. The TEI Header and Its Components 16.1. Varieties of Composite Text]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="tei:fileDesc"/>
+            <xs:element minOccurs="0" ref="tei:encodingDesc"/>
+            <xs:element ref="tei:profileDesc"/>
+            <xs:element minOccurs="0" ref="tei:xenoData"/>
+            <xs:element minOccurs="0" ref="tei:revisionDesc"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="fileDesc">
+      <xs:annotation>
+         <xs:documentation>(file description) contains a full bibliographic description of an electronic file. [2.2. The File Description 2.1.1. The TEI Header and Its Components]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:sequence>
+               <xs:element ref="tei:titleStmt"/>
+               <xs:element minOccurs="0" ref="tei:editionStmt"/>
+               <xs:element minOccurs="0" ref="tei:extent"/>
+               <xs:element ref="tei:publicationStmt"/>
+               <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:seriesStmt"/>
+               <xs:element minOccurs="0" ref="tei:notesStmt"/>
+            </xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:sourceDesc"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="titleStmt">
+      <xs:annotation>
+         <xs:documentation>(title statement) groups information about the title of a work and those responsible for its content. [2.2.1. The Title Statement 2.2. The File Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="tei:title"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:model.respLike"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="principal" substitutionGroup="tei:model.respLike">
+      <xs:annotation>
+         <xs:documentation>(principal researcher) supplies the name of the principal researcher responsible for the creation of an electronic text. [2.2.1. The Title Statement]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="editionStmt">
+      <xs:annotation>
+         <xs:documentation>(edition statement) groups information relating to one edition of a text. [2.2.2. The Edition Statement 2.2. The File Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:sequence>
+               <xs:element ref="tei:edition"/>
+               <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:model.respLike"/>
+            </xs:sequence>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="edition">
+      <xs:annotation>
+         <xs:documentation>(edition) describes the particularities of one edition of a text. [2.2.2. The Edition Statement]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="extent">
+      <xs:annotation>
+         <xs:documentation>(extent) describes the approximate size of a text stored on some carrier medium or of some other object, digital or non-digital, specified in any convenient units. [2.2.3. Type and Extent of File 2.2. The File Description 3.12.2.4. Imprint, Size of a Document, and Reprint Information 11.7.1. Object Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="tei:measure"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="publicationStmt">
+      <xs:annotation>
+         <xs:documentation>(publication statement) groups information concerning the publication or distribution of an electronic or other text. [2.2.4. Publication, Distribution, Licensing, etc. 2.2. The File Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice maxOccurs="unbounded">
+            <xs:group maxOccurs="unbounded" ref="tei:model.publicationStmtPart.agency"/>
+            <xs:element ref="tei:availability"/>
+            <xs:group minOccurs="0" ref="tei:model.ptrLike"/>
+            <xs:element minOccurs="0" ref="tei:date"/>
+            <xs:element minOccurs="0" ref="tei:idno"/>
+            <xs:element minOccurs="0" ref="tei:pubPlace"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="authority">
+      <xs:annotation>
+         <xs:documentation>(release authority) supplies the name of a person or other agency responsible for making a work available, other than a publisher or distributor. [2.2.4. Publication, Distribution, Licensing, etc.]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+               <xs:attribute name="role">
+                  <xs:annotation>
+                     <xs:documentation>
+Suggested values include: 1] funder; 2] sponsor; 3] rightsHolder</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union memberTypes="xs:Name">
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="funder">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="sponsor">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="rightsHolder">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="idno">
+      <xs:annotation>
+         <xs:documentation>(identifier) supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way. [14.3.1. Basic Principles 2.2.4. Publication, Distribution, Licensing, etc. 2.2.5. The Series Statement 3.12.2.4. Imprint, Size of a Document, and Reprint Information]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="tei:model.gLike"/>
+            <xs:element ref="tei:idno"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.datable.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type">
+            <xs:annotation>
+               <xs:documentation>categorizes the identifier, for example as an ISBN, Social Security number, etc.
+Suggested values include: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7] OCLC</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="ISBN"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="ISSN">
+                           <xs:annotation>
+                              <xs:documentation>International Standard Serial Number: an eight-digit number to uniquely identify a serial publication.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="DOI">
+                           <xs:annotation>
+                              <xs:documentation>Digital Object Identifier: a unique string of letters and numbers assigned to an electronic document.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="URI"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="VIAF">
+                           <xs:annotation>
+                              <xs:documentation>A data number in the Virtual Internet Authority File assigned to link different names in catalogs around the world for the same entity.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="ESTC">
+                           <xs:annotation>
+                              <xs:documentation>English Short-Title Catalogue number: an identifying number assigned to a document in English printed in the British Isles or North America before 1801.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="OCLC">
+                           <xs:annotation>
+                              <xs:documentation>OCLC control number (record number) for the union catalog record in WorldCat, a union catalog for member libraries in the Online Computer Library Center global cooperative.</xs:documentation>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="availability">
+      <xs:annotation>
+         <xs:documentation>(availability) supplies information about the availability of a text, for example any restrictions on its use or distribution, its copyright status, any licence applying to it, etc. [2.2.4. Publication, Distribution, Licensing, etc.]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice maxOccurs="unbounded">
+            <xs:element ref="tei:model.availabilityPart"/>
+            <xs:group ref="tei:model.pLike"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+         <xs:attribute name="status">
+            <xs:annotation>
+               <xs:documentation>(status) supplies a code identifying the current availability of the text.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="free">
+                     <xs:annotation>
+                        <xs:documentation>(free) the text is freely available.</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="unknown">
+                     <xs:annotation>
+                        <xs:documentation>(unknown) the status of the text is unknown.</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="restricted">
+                     <xs:annotation>
+                        <xs:documentation>(restricted) the text is not freely available.</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="licence" substitutionGroup="tei:model.availabilityPart">
+      <xs:annotation>
+         <xs:documentation>contains information about a licence or other legal agreement applicable to the text. [2.2.4. Publication, Distribution, Licensing, etc.]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="seriesStmt">
+      <xs:annotation>
+         <xs:documentation>(series statement) groups information about the series, if any, to which a publication belongs. [2.2.5. The Series Statement 2.2. The File Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:sequence>
+               <xs:element maxOccurs="unbounded" ref="tei:title"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="tei:editor"/>
+                  <xs:element ref="tei:respStmt"/>
+               </xs:choice>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="tei:idno"/>
+                  <xs:element ref="tei:biblScope"/>
+               </xs:choice>
+            </xs:sequence>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="notesStmt">
+      <xs:annotation>
+         <xs:documentation>(notes statement) collects together any notes providing information about a text additional to that recorded in other parts of the bibliographic description. [2.2.6. The Notes Statement 2.2. The File Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:group maxOccurs="unbounded" ref="tei:model.noteLike"/>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="sourceDesc">
+      <xs:annotation>
+         <xs:documentation>(source description) describes the source(s) from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as born digital for a text which has no previous existence. [2.2.7. The Source Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="tei:listBibl"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="encodingDesc">
+      <xs:annotation>
+         <xs:documentation>(encoding description) documents the relationship between an electronic text and the source or sources from which it was derived. [2.3. The Encoding Description 2.1.1. The TEI Header and Its Components]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice maxOccurs="unbounded">
+            <xs:element ref="tei:model.encodingDescPart"/>
+            <xs:group ref="tei:model.pLike"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="projectDesc" substitutionGroup="tei:model.encodingDescPart">
+      <xs:annotation>
+         <xs:documentation>(project description) describes in detail the aim or purpose for which an electronic file was encoded, together with any other relevant information concerning the process by which it was assembled or collected. [2.3.1. The Project Description 2.3. The Encoding Description 16.3.2. Declarable Elements]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="editorialDecl" substitutionGroup="tei:model.encodingDescPart">
+      <xs:annotation>
+         <xs:documentation>(editorial practice declaration) provides details of editorial principles and practices applied during the encoding of a text. [2.3.3. The Editorial Practices Declaration 2.3. The Encoding Description 16.3.2. Declarable Elements]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="tagsDecl" substitutionGroup="tei:model.encodingDescPart">
+      <xs:annotation>
+         <xs:documentation>(tagging declaration) provides detailed information about the tagging applied to a document. [2.3.4. The Tagging Declaration 2.3. The Encoding Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:rendition"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:namespace"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attribute name="partial" type="xs:boolean"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="tagUsage">
+      <xs:annotation>
+         <xs:documentation>(element usage) documents the usage of a specific element within a specified document. [2.3.4. The Tagging Declaration]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.limitedContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datcat.attributes"/>
+               <xs:attribute name="gi" use="required" type="xs:Name"/>
+               <xs:attribute name="occurs" type="xs:nonNegativeInteger">
+                  <xs:annotation>
+                     <xs:documentation>specifies the number of occurrences of this element within the text.</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+               <xs:attribute name="withId" type="xs:nonNegativeInteger"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="namespace">
+      <xs:annotation>
+         <xs:documentation>(namespace) supplies the formal name of the namespace to which the elements documented by its children belong. [2.3.4. The Tagging Declaration]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="tei:tagUsage"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attribute name="name" use="required">
+            <xs:annotation>
+               <xs:documentation>specifies the full formal name of the namespace concerned.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:union>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:length value="0"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="rendition">
+      <xs:annotation>
+         <xs:documentation>(rendition) supplies information about the rendition or appearance of one or more elements in the source text. [2.3.4. The Tagging Declaration]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.limitedContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.styleDef.attributes"/>
+               <xs:attribute name="scope">
+                  <xs:annotation>
+                     <xs:documentation>where CSS is used, provides a way of defining pseudo-elements, that is, styling rules applicable to specific sub-portions of an element.
+Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="selector" type="xs:string"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="classDecl" substitutionGroup="tei:model.encodingDescPart">
+      <xs:annotation>
+         <xs:documentation>(classification declarations) contains one or more taxonomies defining any classificatory codes used elsewhere in the text. [2.3.7. The Classification Declaration 2.3. The Encoding Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="tei:taxonomy"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="taxonomy">
+      <xs:annotation>
+         <xs:documentation>(taxonomy) defines a typology either implicitly, by means of a bibliographic citation, or explicitly by a structured taxonomy. [2.3.7. The Classification Declaration]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:choice>
+               <xs:choice maxOccurs="unbounded">
+                  <xs:element ref="tei:category"/>
+                  <xs:element ref="tei:taxonomy"/>
+               </xs:choice>
+               <xs:sequence>
+                  <xs:choice maxOccurs="unbounded">
+                     <xs:group ref="tei:model.descLike"/>
+                     <xs:element ref="tei:gloss"/>
+                  </xs:choice>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="tei:category"/>
+                     <xs:element ref="tei:taxonomy"/>
+                  </xs:choice>
+               </xs:sequence>
+            </xs:choice>
+            <xs:sequence>
+               <xs:group ref="tei:model.biblLike"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="tei:category"/>
+                  <xs:element ref="tei:taxonomy"/>
+               </xs:choice>
+            </xs:sequence>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.datcat.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="category">
+      <xs:annotation>
+         <xs:documentation>(category) contains an individual descriptive category, possibly nested within a superordinate category, within a user-defined taxonomy. [2.3.7. The Classification Declaration]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice>
+               <xs:element maxOccurs="unbounded" ref="tei:catDesc"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="tei:model.descLike"/>
+                  <xs:element ref="tei:gloss"/>
+               </xs:choice>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:category"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.datcat.attributes"/>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="catDesc">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="tei:term"/>
+            <xs:element minOccurs="0" ref="tei:gloss"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="appInfo"
+               substitutionGroup="tei:model.encodingDescPart"
+               abstract="true">
+      <xs:annotation>
+         <xs:documentation>(application information) records information about an application which has edited the TEI file. [2.3.11. The Application Information Element]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="profileDesc">
+      <xs:annotation>
+         <xs:documentation>(text-profile description) provides a detailed description of non-bibliographic aspects of a text, specifically the languages and sublanguages used, the situation in which it was produced, the participants and their setting. [2.4. The Profile Description 2.1.1. The TEI Header and Its Components]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="tei:model.profileDescPart"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="langUsage" substitutionGroup="tei:model.profileDescPart">
+      <xs:annotation>
+         <xs:documentation>(language usage) describes the languages, sublanguages, registers, dialects, etc. represented within a text. [2.4.2. Language Usage 2.4. The Profile Description 16.3.2. Declarable Elements]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:element maxOccurs="unbounded" ref="tei:language"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="language">
+      <xs:annotation>
+         <xs:documentation>(language) characterizes a single language or sublanguage used within a text. [2.4.2. Language Usage]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.languageProfile"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+         <xs:attribute name="role" use="required">
+            <xs:annotation>
+               <xs:documentation/>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="objectLanguage">
+                     <xs:annotation>
+                        <xs:documentation>Object language is the "language being described." (ISO 16642:2017)</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="workingLanguage">
+                     <xs:annotation>
+                        <xs:documentation>Working language is the "language used to describe objects." (ISO 16642:2017)</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="sourceLanguage">
+                     <xs:annotation>
+                        <xs:documentation>Source language is the language of the content to be translated. (ISO 17100:215)</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="targetLanguage">
+                     <xs:annotation>
+                        <xs:documentation>Target language is the language of the content into which source language content is translated. (ISO 17100:215)</xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="status">
+            <xs:annotation>
+               <xs:documentation/>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ident" use="required">
+            <xs:simpleType>
+               <xs:union memberTypes="xs:language">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:enumeration value="">
+                           <xs:annotation>
+                              <xs:documentation/>
+                           </xs:annotation>
+                        </xs:enumeration>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:union>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="usage" type="xs:nonNegativeInteger">
+            <xs:annotation>
+               <xs:documentation>specifies the approximate percentage of the text which uses this language.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="xenoData">
+      <xs:annotation>
+         <xs:documentation>(non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:anyElement_xenoData_1"/>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.declarable.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="revisionDesc">
+      <xs:annotation>
+         <xs:documentation>(revision description) summarizes the revision history for a file. [2.6. The Revision Description 2.1.1. The TEI Header and Its Components]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:element maxOccurs="unbounded" ref="tei:list"/>
+            <xs:element maxOccurs="unbounded" ref="tei:change"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.docStatus.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="change">
+      <xs:annotation>
+         <xs:documentation>(change) documents a change or set of changes made during the production of a source document, or during the revision of an electronic file. [2.6. The Revision Description 2.4.1. Creation 12.7. Identifying Changes and Revisions]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.specialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.ascribed.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.docStatus.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attribute name="target">
+                  <xs:annotation>
+                     <xs:documentation>(target) points to one or more elements that belong to this change.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction>
+                        <xs:simpleType>
+                           <xs:list>
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:anyURI">
+                                    <xs:pattern value="\S+"/>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:list>
+                        </xs:simpleType>
+                        <xs:minLength value="1"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.global.linking.attributes">
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.corresp"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.synch"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.sameAs"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.copyOf"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.next"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.prev"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.exclude"/>
+      <xs:attributeGroup ref="tei:att.global.linking.attribute.select"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.corresp">
+      <xs:attribute name="corresp">
+         <xs:annotation>
+            <xs:documentation>(corresponds) points to elements that correspond to the current element in some way.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.synch">
+      <xs:attribute name="synch">
+         <xs:annotation>
+            <xs:documentation>(synchronous) points to elements that are synchronous with the current element.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.sameAs">
+      <xs:attribute name="sameAs">
+         <xs:annotation>
+            <xs:documentation>points to an element that is the same as the current element.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.copyOf">
+      <xs:attribute name="copyOf">
+         <xs:annotation>
+            <xs:documentation>points to an element of which the current element is a copy.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.next">
+      <xs:attribute name="next">
+         <xs:annotation>
+            <xs:documentation>(next) points to the next element of a virtual aggregate of which the current element is part.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.prev">
+      <xs:attribute name="prev">
+         <xs:annotation>
+            <xs:documentation>(previous) points to the previous element of a virtual aggregate of which the current element is part.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.exclude">
+      <xs:attribute name="exclude">
+         <xs:annotation>
+            <xs:documentation>points to elements that are in exclusive alternation with the current element.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.linking.attribute.select">
+      <xs:attribute name="select">
+         <xs:annotation>
+            <xs:documentation>selects one or more alternants; if one alternant is selected, the ambiguity or uncertainty is marked as resolved. If more than one alternant is selected, the degree of ambiguity or uncertainty is marked as reduced by the number of alternants not selected.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="seg">
+      <xs:annotation>
+         <xs:documentation>(arbitrary segment) represents any segmentation of text below the chunk level. [17.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.lexParaContent">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.notated.attributes"/>
+               <xs:attributeGroup ref="tei:att.segLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attributeGroup ref="tei:att.written.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.datable.custom.attributes">
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.when-custom"/>
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.notBefore-custom"/>
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.notAfter-custom"/>
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.from-custom"/>
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.to-custom"/>
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.datingPoint"/>
+      <xs:attributeGroup ref="tei:att.datable.custom.attribute.datingMethod"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.when-custom">
+      <xs:attribute name="when-custom">
+         <xs:annotation>
+            <xs:documentation>supplies the value of a date or time in some custom standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.notBefore-custom">
+      <xs:attribute name="notBefore-custom">
+         <xs:annotation>
+            <xs:documentation>specifies the earliest possible date for the event in some custom standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.notAfter-custom">
+      <xs:attribute name="notAfter-custom">
+         <xs:annotation>
+            <xs:documentation>specifies the latest possible date for the event in some custom standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.from-custom">
+      <xs:attribute name="from-custom">
+         <xs:annotation>
+            <xs:documentation>indicates the starting point of the period in some custom standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.to-custom">
+      <xs:attribute name="to-custom">
+         <xs:annotation>
+            <xs:documentation>indicates the ending point of the period in some custom standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.datingPoint">
+      <xs:attribute name="datingPoint">
+         <xs:annotation>
+            <xs:documentation>supplies a pointer to some location defining a named point in time with reference to which the datable item is understood to have occurred.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.custom.attribute.datingMethod">
+      <xs:attribute name="datingMethod">
+         <xs:simpleType>
+            <xs:restriction base="xs:anyURI">
+               <xs:pattern value="\S+"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:group name="model.persNamePart">
+      <xs:choice>
+         <xs:element ref="tei:surname"/>
+         <xs:element ref="tei:forename"/>
+         <xs:element ref="tei:persPronouns"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.persNamePart_alternation">
+      <xs:choice>
+         <xs:element ref="tei:surname"/>
+         <xs:element ref="tei:forename"/>
+         <xs:element ref="tei:persPronouns"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.persNamePart_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:surname"/>
+         <xs:element ref="tei:forename"/>
+         <xs:element ref="tei:persPronouns"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.persNamePart_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:surname"/>
+         <xs:element minOccurs="0" ref="tei:forename"/>
+         <xs:element minOccurs="0" ref="tei:persPronouns"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.persNamePart_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:surname"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:forename"/>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:persPronouns"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.persNamePart_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:surname"/>
+         <xs:element maxOccurs="unbounded" ref="tei:forename"/>
+         <xs:element maxOccurs="unbounded" ref="tei:persPronouns"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:attributeGroup name="att.datable.iso.attributes">
+      <xs:attributeGroup ref="tei:att.datable.iso.attribute.when-iso"/>
+      <xs:attributeGroup ref="tei:att.datable.iso.attribute.notBefore-iso"/>
+      <xs:attributeGroup ref="tei:att.datable.iso.attribute.notAfter-iso"/>
+      <xs:attributeGroup ref="tei:att.datable.iso.attribute.from-iso"/>
+      <xs:attributeGroup ref="tei:att.datable.iso.attribute.to-iso"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.iso.attribute.when-iso">
+      <xs:attribute name="when-iso">
+         <xs:annotation>
+            <xs:documentation>supplies the value of a date or time in a standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[0-9.,DHMPRSTWYZ/:+\-]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.iso.attribute.notBefore-iso">
+      <xs:attribute name="notBefore-iso">
+         <xs:annotation>
+            <xs:documentation>specifies the earliest possible date for the event in standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[0-9.,DHMPRSTWYZ/:+\-]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.iso.attribute.notAfter-iso">
+      <xs:attribute name="notAfter-iso">
+         <xs:annotation>
+            <xs:documentation>specifies the latest possible date for the event in standard form, e.g. yyyy-mm-dd.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[0-9.,DHMPRSTWYZ/:+\-]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.iso.attribute.from-iso">
+      <xs:attribute name="from-iso">
+         <xs:annotation>
+            <xs:documentation>indicates the starting point of the period in standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[0-9.,DHMPRSTWYZ/:+\-]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.datable.iso.attribute.to-iso">
+      <xs:attribute name="to-iso">
+         <xs:annotation>
+            <xs:documentation>indicates the ending point of the period in standard form.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union memberTypes="xs:date xs:gYear xs:gMonth xs:gDay xs:gYearMonth xs:gMonthDay xs:time xs:dateTime">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:pattern value="[0-9.,DHMPRSTWYZ/:+\-]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="orgName">
+      <xs:annotation>
+         <xs:documentation>(organization name) contains an organizational name. [14.2.2. Organizational Names]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.personal.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="persName">
+      <xs:annotation>
+         <xs:documentation>(personal name) contains a proper noun or proper-noun phrase referring to a person, possibly including one or more of the person's forenames, surnames, honorifics, added names, etc. [14.2.1. Personal Names]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.personal.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="surname">
+      <xs:annotation>
+         <xs:documentation>(surname) contains a family (inherited) name, as opposed to a given, baptismal, or nick name. [14.2.1. Personal Names]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.personal.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="forename">
+      <xs:annotation>
+         <xs:documentation>(forename) contains a forename, given or baptismal name. [14.2.1. Personal Names]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.personal.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="placeName">
+      <xs:annotation>
+         <xs:documentation>(place name) contains an absolute or relative place name. [14.2.3. Place Names]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.personal.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="affiliation">
+      <xs:annotation>
+         <xs:documentation>(affiliation) contains an informal description of a person's present or past affiliation with some organization, for example an employer or sponsor. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] sponsor; 2] recommend; 3] discredit; 4] pledged</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="age">
+      <xs:annotation>
+         <xs:documentation>(age) specifies the age of a person. [14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.dimensions.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld (in world); 6] chronological; 7] biological; 8] psychological; 9] functional</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="value" type="xs:nonNegativeInteger">
+                  <xs:annotation>
+                     <xs:documentation>supplies a numeric code representing the age or age group.</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="education">
+      <xs:annotation>
+         <xs:documentation>(education) contains a description of the educational experience of a person. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] secondary; 3] undergraduate; 4] graduate; 5] residency; 6] apprenticeship</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="faith">
+      <xs:annotation>
+         <xs:documentation>(faith) specifies the faith, religion, or belief set of a person. [14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.canonical.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] practicing; 2] clandestine; 3] patrilineal; 4] matrilineal; 5] convert</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="floruit">
+      <xs:annotation>
+         <xs:documentation>(floruit) contains information about a person's period of activity. [14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.dimensions.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="gender">
+      <xs:annotation>
+         <xs:documentation>(gender) specifies the gender identity of a person, persona, or character. [14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attribute name="value">
+                  <xs:annotation>
+                     <xs:documentation>supplies a coded value for gender identity.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction>
+                        <xs:simpleType>
+                           <xs:list>
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:token">
+                                    <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:list>
+                        </xs:simpleType>
+                        <xs:minLength value="1"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="langKnowledge">
+      <xs:complexType>
+         <xs:choice>
+            <xs:group ref="tei:model.pLike"/>
+            <xs:element maxOccurs="unbounded" ref="tei:langKnown"/>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.datable.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type">
+            <xs:annotation>
+               <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] listening; 2] speaking; 3] reading; 4] writing</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="tags">
+            <xs:annotation>
+               <xs:documentation>supplies one or more valid language tags for the languages specified.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:union memberTypes="xs:language">
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:token">
+                                    <xs:enumeration value="">
+                                       <xs:annotation>
+                                          <xs:documentation/>
+                                       </xs:annotation>
+                                    </xs:enumeration>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:union>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="langKnown">
+      <xs:annotation>
+         <xs:documentation>(language known) summarizes the state of a person's linguistic competence, i.e., knowledge of a single language. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq.limited">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attribute name="tag" use="required">
+                  <xs:annotation>
+                     <xs:documentation>supplies a valid language tag for the language concerned.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union memberTypes="xs:language">
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="">
+                                 <xs:annotation>
+                                    <xs:documentation/>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="level">
+                  <xs:annotation>
+                     <xs:documentation>a code indicating the person's level of knowledge for this language.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="nationality">
+      <xs:annotation>
+         <xs:documentation>(nationality) contains an informal description of a person's present or past nationality or citizenship. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] birth; 2] naturalised; 3] self-assigned</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="occupation">
+      <xs:annotation>
+         <xs:documentation>(occupation) contains an informal description of a person's trade, profession or occupation. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.specialPara">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] other; 3] paid; 4] unpaid</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="scheme">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="code">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="person">
+      <xs:annotation>
+         <xs:documentation>(person) provides information about an identifiable individual, for example a participant in a language interaction, or a person referred to in a historical source. [14.3.2. The Person Element 16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.personPart"/>
+               <xs:group ref="tei:model.global"/>
+               <xs:group ref="tei:model.ptrLike"/>
+            </xs:choice>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attribute name="role">
+            <xs:annotation>
+               <xs:documentation>specifies a primary role or classification for the person.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="sex">
+            <xs:annotation>
+               <xs:documentation>specifies the sex of the person.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="gender">
+            <xs:annotation>
+               <xs:documentation>specifies the gender of the person.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="age">
+            <xs:annotation>
+               <xs:documentation>specifies an age group for the person.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="persona">
+      <xs:annotation>
+         <xs:documentation>provides information about one of the personalities identified for a given individual, where an individual has multiple personalities. [14.3.2. The Person Element]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.personPart"/>
+               <xs:group ref="tei:model.global"/>
+            </xs:choice>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attribute name="role">
+            <xs:annotation>
+               <xs:documentation>specifies a primary role or classification for the persona.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="sex">
+            <xs:annotation>
+               <xs:documentation>specifies the sex of the persona.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="gender">
+            <xs:annotation>
+               <xs:documentation>specifies the gender of the persona.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="age">
+            <xs:annotation>
+               <xs:documentation>specifies an age group for the persona.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="personGrp">
+      <xs:annotation>
+         <xs:documentation>(personal group) describes a group of individuals treated as a single person for analytic purposes. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.personPart"/>
+               <xs:group ref="tei:model.global"/>
+            </xs:choice>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.sortable.attributes"/>
+         <xs:attribute name="role">
+            <xs:annotation>
+               <xs:documentation>specifies the role of this group of participants in the interaction.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="sex">
+            <xs:annotation>
+               <xs:documentation>specifies the sex of the participant group.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="gender">
+            <xs:annotation>
+               <xs:documentation>specifies the gender of the participant group.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="age">
+            <xs:annotation>
+               <xs:documentation>specifies the age group of the participants.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="size">
+            <xs:annotation>
+               <xs:documentation>describes informally the size or approximate size of the group for example by means of a number and an indication of accuracy e.g. approx 200.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="persPronouns">
+      <xs:annotation>
+         <xs:documentation>(personal pronouns) indicates the personal pronouns used, or assumed to be used, by the individual being described. [14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attribute name="evidence">
+                  <xs:annotation>
+                     <xs:documentation>(evidence) indicates support for the listed personal pronouns.
+Suggested values include: 1] conjecture (conjecture); 2] selfIdentification (self identification); 3] trustedThirdParty (trusted third party)</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:union>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="conjecture">
+                                 <xs:annotation>
+                                    <xs:documentation>(conjecture) The given value was selected based on assumptions by someone besides the person to whom this pronoun applies. As a result, the value may be erroneous.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="selfIdentification">
+                                 <xs:annotation>
+                                    <xs:documentation>(self identification) The given value has been explicitly stated or confirmed by the person to whom this pronoun applies.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:enumeration value="trustedThirdParty">
+                                 <xs:annotation>
+                                    <xs:documentation>(trusted third party) The given value has been supplied by another individual trusted by the encoder to know the preferences of the person to whom this pronoun applies.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:enumeration>
+                           </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:token">
+                              <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:union>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="value">
+                  <xs:annotation>
+                     <xs:documentation>(value) supplies a regularized value for personal pronouns.
+Sample values include: 1] e (e); 2] he (he); 3] she (she); 4] they (they)</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction>
+                        <xs:simpleType>
+                           <xs:list>
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:token">
+                                    <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:list>
+                        </xs:simpleType>
+                        <xs:minLength value="1"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="place" substitutionGroup="tei:model.placeLike">
+      <xs:annotation>
+         <xs:documentation>(place) contains data about a geographic location. [14.3.4. Places]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="residence">
+      <xs:annotation>
+         <xs:documentation>(residence) describes a person's present or past places of residence. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] secondary; 3] temporary; 4] permanent</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="sex">
+      <xs:annotation>
+         <xs:documentation>(sex) specifies the sex of an organism. [14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attributes"/>
+               <xs:attribute name="value">
+                  <xs:annotation>
+                     <xs:documentation>supplies a coded value for sex.</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction>
+                        <xs:simpleType>
+                           <xs:list>
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:token">
+                                    <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:list>
+                        </xs:simpleType>
+                        <xs:minLength value="1"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="socecStatus">
+      <xs:annotation>
+         <xs:documentation>(socio-economic status) contains an informal description of a person's perceived social or economic status. [16.2.2. The Participant Description]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="tei:macro.phraseSeq">
+               <xs:attributeGroup ref="tei:att.global.attributes"/>
+               <xs:attributeGroup ref="tei:att.datable.attributes"/>
+               <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+               <xs:attributeGroup ref="tei:att.naming.attributes"/>
+               <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+               <xs:attribute name="type">
+                  <xs:annotation>
+                     <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] atBirth; 2] atDeath; 3] dependent; 4] inherited; 5] independent</xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleType>
+                     <xs:restriction base="xs:token">
+                        <xs:pattern value="[^\p{C}\p{Z}]+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="scheme">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+               <xs:attribute name="code">
+                  <xs:simpleType>
+                     <xs:restriction base="xs:anyURI">
+                        <xs:pattern value="\S+"/>
+                     </xs:restriction>
+                  </xs:simpleType>
+               </xs:attribute>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="state">
+      <xs:annotation>
+         <xs:documentation>(state) contains a description of some status or quality attributed to a person, place, or organization often at some specific time or for a specific date range. [14.3.1. Basic Principles 14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:element maxOccurs="unbounded" ref="tei:state"/>
+            <xs:sequence>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.headLike"/>
+               <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="tei:model.noteLike"/>
+                  <xs:group ref="tei:model.biblLike"/>
+               </xs:choice>
+            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.labelLike"/>
+               <xs:group ref="tei:model.noteLike"/>
+               <xs:group ref="tei:model.biblLike"/>
+            </xs:choice>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.datable.attributes"/>
+         <xs:attributeGroup ref="tei:att.dimensions.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.naming.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="trait">
+      <xs:annotation>
+         <xs:documentation>(trait) contains a description of some status or quality attributed to a person, place, or organization typically, but not necessarily, independent of the volition or action of the holder and usually not at some specific time or for a specific date range. [14.3.1. Basic Principles 14.3.2.1. Personal Characteristics]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice>
+            <xs:element maxOccurs="unbounded" ref="tei:trait"/>
+            <xs:sequence>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.headLike"/>
+               <xs:group maxOccurs="unbounded" ref="tei:model.pLike"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="tei:model.noteLike"/>
+                  <xs:group ref="tei:model.biblLike"/>
+               </xs:choice>
+            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.labelLike"/>
+               <xs:group ref="tei:model.noteLike"/>
+               <xs:group ref="tei:model.biblLike"/>
+            </xs:choice>
+         </xs:choice>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.cmc.attributes"/>
+         <xs:attributeGroup ref="tei:att.datable.attributes"/>
+         <xs:attributeGroup ref="tei:att.dimensions.attributes"/>
+         <xs:attributeGroup ref="tei:att.editLike.attributes"/>
+         <xs:attributeGroup ref="tei:att.naming.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.translatable.attributes">
+      <xs:attributeGroup ref="tei:att.translatable.attribute.versionDate"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.translatable.attribute.versionDate">
+      <xs:attribute name="versionDate">
+         <xs:annotation>
+            <xs:documentation>specifies the date on which the source text was extracted and sent to the translator</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:union>
+               <xs:simpleType>
+                  <xs:restriction base="xs:date">
+                     <xs:pattern value="(19[789][0-9]|[2-9][0-9]{3}).*"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:dateTime">
+                     <xs:pattern value="(19[789][0-9]|[2-9][0-9]{3}).*"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="ident">
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="TEI">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="tei:teiHeader"/>
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="unbounded" ref="tei:model.resource"/>
+                  <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:TEI"/>
+               </xs:sequence>
+               <xs:element maxOccurs="unbounded" ref="tei:TEI"/>
+            </xs:choice>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.typed.attribute.subtype"/>
+         <xs:attribute name="type" use="required">
+            <xs:annotation>
+               <xs:documentation>characterizes the element in some sense, using any convenient classification scheme or typology.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="lex-0">
+                     <xs:annotation>
+                        <xs:documentation/>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="version">
+            <xs:annotation>
+               <xs:documentation>specifies the version number of the TEI Guidelines against which this document is valid.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[\d]+(\.[\d]+){0,2}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="text" substitutionGroup="tei:model.resource">
+      <xs:annotation>
+         <xs:documentation>(text) contains a single text of any kind, whether unitary or composite, for example a poem or drama, a collection of essays, a novel, a dictionary, or a corpus sample. [4. Default Text Structure 16.1. Varieties of Composite Text]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="body">
+      <xs:annotation>
+         <xs:documentation>(text body) contains the whole body of a single unitary text, excluding any front or back matter. [4. Default Text Structure]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+            <xs:sequence minOccurs="0">
+               <xs:group ref="tei:model.divTop"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="tei:model.global"/>
+                  <xs:group ref="tei:model.divTop"/>
+               </xs:choice>
+            </xs:sequence>
+            <xs:choice>
+               <xs:sequence maxOccurs="unbounded">
+                  <xs:element ref="tei:model.divLike"/>
+                  <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:sequence maxOccurs="unbounded">
+                     <xs:group ref="tei:model.common"/>
+                     <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+                  </xs:sequence>
+                  <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="tei:model.divLike"/>
+                     <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
+                  </xs:sequence>
+               </xs:sequence>
+            </xs:choice>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="div" substitutionGroup="tei:model.divLike">
+      <xs:annotation>
+         <xs:documentation>(text division) contains a subdivision of the front, body, or back of a text. [4.1. Divisions of the Body]</xs:documentation>
+      </xs:annotation>
+   </xs:element>
+   <xs:element name="front">
+      <xs:annotation>
+         <xs:documentation>(front matter) contains any prefatory matter (headers, abstracts, title page, prefaces, dedications, etc.) found at the start of a document, before the main body. [4.6. Title Pages 4. Default Text Structure]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.frontPart"/>
+               <xs:group ref="tei:model.pLike"/>
+               <xs:group ref="tei:model.pLike.front"/>
+               <xs:group ref="tei:model.global"/>
+            </xs:choice>
+            <xs:sequence minOccurs="0">
+               <xs:element ref="tei:model.divLike"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:element ref="tei:model.divLike"/>
+                  <xs:group ref="tei:model.frontPart"/>
+                  <xs:group ref="tei:model.global"/>
+               </xs:choice>
+            </xs:sequence>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="back">
+      <xs:annotation>
+         <xs:documentation>(back matter) contains any appendixes, etc. following the main part of a text. [4.7. Back Matter 4. Default Text Structure]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+               <xs:group ref="tei:model.frontPart"/>
+               <xs:group ref="tei:model.pLike.front"/>
+               <xs:group ref="tei:model.pLike"/>
+               <xs:group ref="tei:model.listLike"/>
+               <xs:group ref="tei:model.global"/>
+            </xs:choice>
+            <xs:sequence minOccurs="0">
+               <xs:element ref="tei:model.divLike"/>
+               <xs:choice minOccurs="0" maxOccurs="unbounded">
+                  <xs:group ref="tei:model.frontPart"/>
+                  <xs:element ref="tei:model.divLike"/>
+                  <xs:group ref="tei:model.global"/>
+               </xs:choice>
+            </xs:sequence>
+         </xs:sequence>
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="att.global.facs.attributes">
+      <xs:attributeGroup ref="tei:att.global.facs.attribute.facs"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.facs.attribute.facs">
+      <xs:attribute name="facs">
+         <xs:annotation>
+            <xs:documentation>(facsimile) points to one or more images, portions of an image, or surfaces which correspond to the current element.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.change.attributes">
+      <xs:attributeGroup ref="tei:att.global.change.attribute.change"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.global.change.attribute.change">
+      <xs:attribute name="change">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:anyURI">
+                           <xs:pattern value="\S+"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="metamark">
+      <xs:annotation>
+         <xs:documentation>contains or describes any kind of graphic or written signal within a document the function of which is to determine how it should be read rather than forming part of the actual content of the document. [12.3.4.2. Metamarks]</xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="tei:att.global.attributes"/>
+         <xs:attributeGroup ref="tei:att.placement.attributes"/>
+         <xs:attributeGroup ref="tei:att.spanning.attributes"/>
+         <xs:attribute name="function">
+            <xs:annotation>
+               <xs:documentation>describes the function (for example status, insertion, deletion, transposition) of the metamark.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="[^\p{C}\p{Z}]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attribute name="target">
+            <xs:annotation>
+               <xs:documentation>identifies one or more elements to which the metamark applies.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction>
+                  <xs:simpleType>
+                     <xs:list>
+                        <xs:simpleType>
+                           <xs:restriction base="xs:anyURI">
+                              <xs:pattern value="\S+"/>
+                           </xs:restriction>
+                        </xs:simpleType>
+                     </xs:list>
+                  </xs:simpleType>
+                  <xs:minLength value="1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="model.languageProfile">
+      <xs:choice>
+         <xs:element ref="tei:desc"/>
+         <xs:element ref="tei:name"/>
+         <xs:element ref="tei:date"/>
+         <xs:element ref="tei:note"/>
+         <xs:element ref="tei:bibl"/>
+         <xs:element ref="tei:listBibl"/>
+         <xs:element ref="tei:settingDesc"/>
+         <xs:element ref="tei:channel"/>
+         <xs:element ref="tei:domain"/>
+         <xs:element ref="tei:interaction"/>
+         <xs:element ref="tei:purpose"/>
+         <xs:element ref="tei:person"/>
+         <xs:element ref="tei:personGrp"/>
+         <xs:element ref="tei:ident"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.lexEmphLike">
+      <xs:sequence>
+         <xs:element ref="tei:gloss"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.lexEmphLike_alternation">
+      <xs:sequence>
+         <xs:element ref="tei:gloss"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.lexEmphLike_sequence">
+      <xs:sequence>
+         <xs:element ref="tei:gloss"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.lexEmphLike_sequenceOptional">
+      <xs:sequence>
+         <xs:element minOccurs="0" ref="tei:gloss"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.lexEmphLike_sequenceOptionalRepeatable">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="tei:gloss"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.lexEmphLike_sequenceRepeatable">
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" ref="tei:gloss"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="model.lexFormPart">
+      <xs:choice>
+         <xs:group ref="tei:model.lexicalRefinement"/>
+         <xs:element ref="tei:form"/>
+         <xs:element ref="tei:orth"/>
+         <xs:element ref="tei:pron"/>
+         <xs:element ref="tei:hyph"/>
+         <xs:element ref="tei:syll"/>
+         <xs:element ref="tei:stress"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.lexInter">
+      <xs:choice>
+         <xs:group ref="tei:model.biblLike"/>
+         <xs:group ref="tei:model.attributable"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.lexPhrase">
+      <xs:choice>
+         <xs:group ref="tei:model.segLike"/>
+         <xs:group ref="tei:model.hiLike"/>
+         <xs:group ref="tei:model.ptrLike"/>
+         <xs:element ref="tei:ruby"/>
+         <xs:element ref="tei:lang"/>
+         <xs:group ref="tei:model.lexEmphLike"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="model.sensePart">
+      <xs:choice>
+         <xs:group ref="tei:model.global"/>
+         <xs:element ref="tei:cit"/>
+         <xs:element ref="tei:num"/>
+         <xs:group ref="tei:model.lexicalRefinement"/>
+         <xs:element ref="tei:entry"/>
+         <xs:element ref="tei:sense"/>
+         <xs:element ref="tei:form"/>
+         <xs:element ref="tei:def"/>
+         <xs:element ref="tei:etym"/>
+         <xs:element ref="tei:xr"/>
+         <xs:group ref="tei:model.lexPhrase"/>
+      </xs:choice>
+   </xs:group>
+   <xs:attributeGroup name="att.scoped.attributes">
+      <xs:attributeGroup ref="tei:att.scoped.attribute.scope"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="att.scoped.attribute.scope">
+      <xs:attribute name="scope">
+         <xs:annotation>
+            <xs:documentation>TEI Lex-0 specific class for providing elements with an attribute describing their extent.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:attributeGroup>
+</xs:schema>

--- a/Schemas/TEILex0/out/xml.tmp
+++ b/Schemas/TEILex0/out/xml.tmp
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:tei="http://www.tei-c.org/ns/1.0">
+  <xs:import namespace="http://www.tei-c.org/ns/1.0" schemaLocation="TEILex0.xsd.tmp"/>
+  <xs:attribute name="id" type="xs:ID">
+    <xs:annotation>
+      <xs:documentation>(identifier) provides a unique identifier for the element bearing the attribute.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="lang">
+    <xs:simpleType>
+      <xs:union memberTypes="xs:language">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="">
+              <xs:annotation>
+                <xs:documentation/>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="base">
+    <xs:annotation>
+      <xs:documentation>provides a base URI reference with which applications can resolve relative URI references into absolute URI references.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:anyURI">
+        <xs:pattern value="\S+"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:schema>


### PR DESCRIPTION
XSD UPA violations occur when the generated schema allows the same element to be matched through multiple alternative paths in the content model, making validation ambiguous because XML Schema requires deterministic element attribution. This doesn't occur in RelaxNG. Fixes DARIAH-ERIC/tei-lex-0#119 